### PR TITLE
Added more expansive orientation support

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1065,19 +1065,49 @@ extension Device {
   // MARK: - Orientation
     /**
       This enum describes the state of the orientation.
-      - Landscape: The device is in Landscape Orientation
-      - Portrait:  The device is in Portrait Orientation
+      - Landscape Left: The device is in Landscape Left Orientation.
+      - Landscape Right: The device is in Landscape Right Orientation.
+      - Portrait:  The device is in Portrait Orientation.
+      - Portrait Upside Down:  The device is in Portrait Upside Down Orientation.
+      - Face Up: The device is in Face Up Orientation.
+      - Face Down: The device is in Face Down Orientation.
+      - Unknown: The device is in an Unknown orientation.
     */
     public enum Orientation {
-      case landscape
+      case landscapeLeft
+      case landscapeRight
       case portrait
+      case portraitUpsideDown
+      case faceUp
+      case faceDown
+      case unknown
+
+      var isLandscape: Bool {
+        switch self {
+        case .landscapeLeft, .landscapeRight:
+            return true
+        case .portrait, .portraitUpsideDown, .faceDown, .faceUp, .unknown:
+            return false
+        }
+      }
     }
 
     public var orientation: Orientation {
-      if UIDevice.current.orientation.isLandscape {
-        return .landscape
-      } else {
-        return .portrait
+      switch UIDevice.current.orientation {
+      case .landscapeRight:
+          return .landscapeRight
+      case .landscapeLeft:
+          return .landscapeLeft
+      case .portrait:
+          return .portrait
+      case .portraitUpsideDown:
+          return .portraitUpsideDown
+      case .faceUp:
+          return .faceUp
+      case .faceDown:
+          return .faceDown
+      case .unknown:
+          return .unknown
       }
     }
 }

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -827,19 +827,49 @@ extension Device {
   // MARK: - Orientation
     /**
       This enum describes the state of the orientation.
-      - Landscape: The device is in Landscape Orientation
-      - Portrait:  The device is in Portrait Orientation
+      - Landscape Left: The device is in Landscape Left Orientation.
+      - Landscape Right: The device is in Landscape Right Orientation.
+      - Portrait:  The device is in Portrait Orientation.
+      - Portrait Upside Down:  The device is in Portrait Upside Down Orientation.
+      - Face Up: The device is in Face Up Orientation.
+      - Face Down: The device is in Face Down Orientation.
+      - Unknown: The device is in an Unknown orientation.
     */
     public enum Orientation {
-      case landscape
+      case landscapeLeft
+      case landscapeRight
       case portrait
+      case portraitUpsideDown
+      case faceUp
+      case faceDown
+      case unknown
+
+      var isLandscape: Bool {
+        switch self {
+        case .landscapeLeft, .landscapeRight:
+            return true
+        case .portrait, .portraitUpsideDown, .faceDown, .faceUp, .unknown:
+            return false
+        }
+      }
     }
 
     public var orientation: Orientation {
-      if UIDevice.current.orientation.isLandscape {
-        return .landscape
-      } else {
-        return .portrait
+      switch UIDevice.current.orientation {
+      case .landscapeRight:
+          return .landscapeRight
+      case .landscapeLeft:
+          return .landscapeLeft
+      case .portrait:
+          return .portrait
+      case .portraitUpsideDown:
+          return .portraitUpsideDown
+      case .faceUp:
+          return .faceUp
+      case .faceDown:
+          return .faceDown
+      case .unknown:
+          return .unknown
       }
     }
 }


### PR DESCRIPTION
The current `Orientation` enum isn't really accurate - there are many types of orientations that iOS supports so I think those should be properly represented in the enum.