### PR TITLE
Fix volumeAvailableCapacityForImportantUsage error

### DIFF
--- a/DeviceKit.xcodeproj/project.pbxproj
+++ b/DeviceKit.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Utils/gyb --line-directive '' -o ./Source/Device.generated.swift ./Source/Device.swift.gyb";
+			shellScript = "./Utils/gyb --line-directive '' -o ./Source/Device.generated.swift ./Source/Device.swift.gyb\n";
 		};
 		6D76661D1F1A083A00F59630 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -285,7 +285,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1100,7 +1100,7 @@ extension Device {
   /// Return the root url
   ///
   /// - returns: the "/" url
-  private static let rootURL = URL(fileURLWithPath: "/")
+  private static let rootURL = URL(fileURLWithPath: NSHomeDirectory())
 
   /// The volume’s total capacity in bytes.
   public static var volumeTotalCapacity: Int? {

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1099,7 +1099,7 @@ extension Device {
 
   /// Return the root url
   ///
-  /// - returns: the "/" url
+  /// - returns: the NSHomeDirectory() url
   private static let rootURL = URL(fileURLWithPath: NSHomeDirectory())
 
   /// The volume’s total capacity in bytes.

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -851,8 +851,8 @@ extension Device {
 
   /// Return the root url
   ///
-  /// - returns: the "/" url
-  private static let rootURL = URL(fileURLWithPath: "/")
+  /// - returns: the NSHomeDirectory() url
+  private static let rootURL = URL(fileURLWithPath: NSHomeDirectory())
 
   /// The volume’s total capacity in bytes.
   public static var volumeTotalCapacity: Int? {


### PR DESCRIPTION
when use Device.volumeAvailableCapacityForImportantUsage cause error:

> [client] Failed to get available space for volume /: Error Domain=CacheDeleteErrorDomain Code=10 "(null)" UserInfo={Volume=/}