### PR TITLE
Add property to determine if device is compatible with Apple Pencil

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -638,6 +638,11 @@ public enum Device {
       return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr, .iPadPro11Inch, .iPadPro12Inch3]
     }
 
+    /// All Apple Pencil Capable Devices
+    public static var allApplePencilCapableDevices: [Device] {
+      return [.iPad6, .iPadAir3, .iPadMini5, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3]
+    }
+
     /// Returns whether or not the device has Touch ID
     public var isTouchIDCapable: Bool {
       return isOneOf(Device.allTouchIDCapableDevices)
@@ -653,6 +658,10 @@ public enum Device {
       return isTouchIDCapable || isFaceIDCapable
     }
 
+    /// Returns whether or not the device is compatible with Apple Pencil
+    public var isApplePencilCapable: Bool {
+      return isOneOf(Device.allApplePencilCapableDevices)
+    }
   #elseif os(tvOS)
     /// All TVs
     public static var allTVs: [Device] {

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -638,11 +638,6 @@ public enum Device {
       return [.iPhoneX, .iPhoneXs, .iPhoneXsMax, .iPhoneXr, .iPadPro11Inch, .iPadPro12Inch3]
     }
 
-    /// All Apple Pencil Capable Devices
-    public static var allApplePencilCapableDevices: [Device] {
-      return [.iPad6, .iPadAir3, .iPadMini5, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3]
-    }
-
     /// Returns whether or not the device has Touch ID
     public var isTouchIDCapable: Bool {
       return isOneOf(Device.allTouchIDCapableDevices)
@@ -656,11 +651,6 @@ public enum Device {
     /// Returns whether or not the device has any biometric sensor (i.e. Touch ID or Face ID)
     public var hasBiometricSensor: Bool {
       return isTouchIDCapable || isFaceIDCapable
-    }
-
-    /// Returns whether or not the device is compatible with Apple Pencil
-    public var isApplePencilCapable: Bool {
-      return isOneOf(Device.allApplePencilCapableDevices)
     }
   #elseif os(tvOS)
     /// All TVs
@@ -1161,6 +1151,49 @@ extension Device {
       }
     } catch {
       return nil
+    }
+  }
+}
+#endif
+
+#if os(iOS)
+// MARK: - Apple Pencil
+extension Device {
+
+  /**
+    This option set describes the current Apple Pencils
+    - firstGeneration:  1st Generation Apple Pencil
+    - secondGeneration: 2nd Generation Apple Pencil
+   */
+  public struct ApplePencilSupport: OptionSet {
+
+    public var rawValue: UInt
+    public init(rawValue: UInt) {
+      self.rawValue = rawValue
+    }
+
+    public static let firstGeneration = ApplePencilSupport(rawValue: 0x01)
+    public static let secondGeneration = ApplePencilSupport(rawValue: 0x02)
+  }
+
+  /// All Apple Pencil Capable Devices
+  public static var allApplePencilCapableDevices: [Device] {
+    return [.iPad6, .iPadAir3, .iPadMini5, .iPadPro9Inch, .iPadPro12Inch, .iPadPro12Inch2, .iPadPro10Inch, .iPadPro11Inch, .iPadPro12Inch3]
+  }
+
+  /// Returns supported version of the Apple Pencil
+  public var applePencilSupport: ApplePencilSupport {
+    switch self {
+      case .iPad6: return .firstGeneration
+      case .iPadAir3: return .firstGeneration
+      case .iPadMini5: return .firstGeneration
+      case .iPadPro9Inch: return .firstGeneration
+      case .iPadPro12Inch: return .firstGeneration
+      case .iPadPro12Inch2: return .firstGeneration
+      case .iPadPro10Inch: return .firstGeneration
+      case .iPadPro11Inch: return .secondGeneration
+      case .iPadPro12Inch3: return .secondGeneration
+      default: return []
     }
   }
 }

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -12,7 +12,7 @@
 %{
 class Device:
 
-  def __init__(self, caseName, comment, imageURL, identifiers, diagonal, screenRatio, description, ppi, isPlusFormFactor, isPadMiniFormFactor, isPro, isXSeries, hasTouchID, hasFaceID):
+  def __init__(self, caseName, comment, imageURL, identifiers, diagonal, screenRatio, description, ppi, isPlusFormFactor, isPadMiniFormFactor, isPro, isXSeries, hasTouchID, hasFaceID, hasApplePencil):
     self.caseName = caseName
     self.comment = comment
     self.imageURL = imageURL
@@ -27,64 +27,65 @@ class Device:
     self.isXSeries = isXSeries
     self.hasTouchID = hasTouchID
     self.hasFaceID = hasFaceID
+    self.hasApplePencil = hasApplePencil
 
 # iOS
 iPods = [
-            Device("iPodTouch5",      "Device is an [iPod Touch (5th generation)](https://support.apple.com/kb/SP657)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP657/sp657_ipod-touch_size.jpg",                ["iPod5,1"],                                  4,    (9, 16),  "iPod Touch 5", 326, False, False, False, False, False, False),
-            Device("iPodTouch6",      "Device is an [iPod Touch (6th generation)](https://support.apple.com/kb/SP720)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP720/SP720-ipod-touch-specs-color-sg-2015.jpg", ["iPod7,1"],                                  4,    (9, 16),  "iPod Touch 6", 326, False, False, False, False, False, False)
+            Device("iPodTouch5",      "Device is an [iPod Touch (5th generation)](https://support.apple.com/kb/SP657)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP657/sp657_ipod-touch_size.jpg",                ["iPod5,1"],                                  4,    (9, 16),  "iPod Touch 5", 326, False, False, False, False, False, False, False),
+            Device("iPodTouch6",      "Device is an [iPod Touch (6th generation)](https://support.apple.com/kb/SP720)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP720/SP720-ipod-touch-specs-color-sg-2015.jpg", ["iPod7,1"],                                  4,    (9, 16),  "iPod Touch 6", 326, False, False, False, False, False, False, False)
         ]
 
 iPhones = [
-            Device("iPhone4",         "Device is an [iPhone 4](https://support.apple.com/kb/SP587)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP643/sp643_iphone4s_color_black.jpg",           ["iPhone3,1", "iPhone3,2", "iPhone3,3"],      3.5,  (2, 3),   "iPhone 4", 326, False, False, False, False, False, False),
-            Device("iPhone4s",        "Device is an [iPhone 4s](https://support.apple.com/kb/SP643)",                   "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone5s/iphone_4s.png",  ["iPhone4,1"],                                3.5,  (2, 3),   "iPhone 4s", 326, False, False, False, False, False, False),
-            Device("iPhone5",         "Device is an [iPhone 5](https://support.apple.com/kb/SP655)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP655/sp655_iphone5_color.jpg",                  ["iPhone5,1", "iPhone5,2"],                   4,    (9, 16),  "iPhone 5", 326, False, False, False, False, False, False),
-            Device("iPhone5c",        "Device is an [iPhone 5c](https://support.apple.com/kb/SP684)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP684/SP684-color_yellow.jpg",                   ["iPhone5,3", "iPhone5,4"],                   4,    (9, 16),  "iPhone 5c", 326, False, False, False, False, False, False),
-            Device("iPhone5s",        "Device is an [iPhone 5s](https://support.apple.com/kb/SP685)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP685/SP685-color_black.jpg",                    ["iPhone6,1", "iPhone6,2"],                   4,    (9, 16),  "iPhone 5s", 326, False, False, False, False, True, False),
-            Device("iPhone6",         "Device is an [iPhone 6](https://support.apple.com/kb/SP705)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP705/SP705-iphone_6-mul.png",                   ["iPhone7,2"],                                4.7,  (9, 16),  "iPhone 6", 326, False, False, False, False, True, False),
-            Device("iPhone6Plus",     "Device is an [iPhone 6 Plus](https://support.apple.com/kb/SP706)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP706/SP706-iphone_6_plus-mul.png",              ["iPhone7,1"],                                5.5,  (9, 16),  "iPhone 6 Plus", 401, True, False, False, False, True, False),
-            Device("iPhone6s",        "Device is an [iPhone 6s](https://support.apple.com/kb/SP726)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP726/SP726-iphone6s-gray-select-2015.png",      ["iPhone8,1"],                                4.7,  (9, 16),  "iPhone 6s", 326, False, False, False, False, True, False),
-            Device("iPhone6sPlus",    "Device is an [iPhone 6s Plus](https://support.apple.com/kb/SP727)",              "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP727/SP727-iphone6s-plus-gray-select-2015.png", ["iPhone8,2"],                                5.5,  (9, 16),  "iPhone 6s Plus", 401, True, False, False, False, True, False),
-            Device("iPhone7",         "Device is an [iPhone 7](https://support.apple.com/kb/SP743)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP743/iphone7-black.png",                        ["iPhone9,1", "iPhone9,3"],                   4.7,  (9, 16),  "iPhone 7", 326, False, False, False, False, True, False),
-            Device("iPhone7Plus",     "Device is an [iPhone 7 Plus](https://support.apple.com/kb/SP744)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP744/iphone7-plus-black.png",                   ["iPhone9,2", "iPhone9,4"],                   5.5,  (9, 16),  "iPhone 7 Plus", 401, True, False, False, False, True, False),
-            Device("iPhoneSE",        "Device is an [iPhone SE](https://support.apple.com/kb/SP738)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP738/SP738.png",                                ["iPhone8,4"],                                4,    (9, 16),  "iPhone SE", 326, False, False, False, False, True, False),
-            Device("iPhone8",         "Device is an [iPhone 8](https://support.apple.com/kb/SP767)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP767/iphone8.png",                              ["iPhone10,1", "iPhone10,4"],                 4.7,  (9, 16),  "iPhone 8", 326, False, False, False, False, True, False),
-            Device("iPhone8Plus",     "Device is an [iPhone 8 Plus](https://support.apple.com/kb/SP768)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP768/iphone8plus.png",                          ["iPhone10,2", "iPhone10,5"],                 5.5,  (9, 16),  "iPhone 8 Plus", 401, True, False, False, False, True, False),
-            Device("iPhoneX",         "Device is an [iPhone X](https://support.apple.com/kb/SP770)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP770/iphonex.png",                              ["iPhone10,3", "iPhone10,6"],                 5.8,  (9, 19.5),  "iPhone X", 458, False, False, False, True, False, True),
-            Device("iPhoneXs",        "Device is an [iPhone Xs](https://support.apple.com/kb/SP779)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP779/SP779-iphone-xs.jpg",                      ["iPhone11,2"],                               5.8,  (9, 19.5),  "iPhone Xs", 458, False, False, False, True, False, True),
-            Device("iPhoneXsMax",     "Device is an [iPhone Xs Max](https://support.apple.com/kb/SP780)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP780/SP780-iPhone-Xs-Max.jpg",                  ["iPhone11,4", "iPhone11,6"],                 6.5,  (9, 19.5),  "iPhone Xs Max", 458, False, False, False, True, False, True),
-            Device("iPhoneXr",        "Device is an [iPhone Xr](https://support.apple.com/kb/SP781)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP781/SP781-iPhone-xr.jpg",                      ["iPhone11,8"],                               6.1,  (9, 19.5),  "iPhone Xr", 326, False, False, False, True, False, True)
+            Device("iPhone4",         "Device is an [iPhone 4](https://support.apple.com/kb/SP587)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP643/sp643_iphone4s_color_black.jpg",           ["iPhone3,1", "iPhone3,2", "iPhone3,3"],      3.5,  (2, 3),   "iPhone 4", 326, False, False, False, False, False, False, False),
+            Device("iPhone4s",        "Device is an [iPhone 4s](https://support.apple.com/kb/SP643)",                   "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone5s/iphone_4s.png",  ["iPhone4,1"],                                3.5,  (2, 3),   "iPhone 4s", 326, False, False, False, False, False, False, False),
+            Device("iPhone5",         "Device is an [iPhone 5](https://support.apple.com/kb/SP655)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP655/sp655_iphone5_color.jpg",                  ["iPhone5,1", "iPhone5,2"],                   4,    (9, 16),  "iPhone 5", 326, False, False, False, False, False, False, False),
+            Device("iPhone5c",        "Device is an [iPhone 5c](https://support.apple.com/kb/SP684)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP684/SP684-color_yellow.jpg",                   ["iPhone5,3", "iPhone5,4"],                   4,    (9, 16),  "iPhone 5c", 326, False, False, False, False, False, False, False),
+            Device("iPhone5s",        "Device is an [iPhone 5s](https://support.apple.com/kb/SP685)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP685/SP685-color_black.jpg",                    ["iPhone6,1", "iPhone6,2"],                   4,    (9, 16),  "iPhone 5s", 326, False, False, False, False, True, False, False),
+            Device("iPhone6",         "Device is an [iPhone 6](https://support.apple.com/kb/SP705)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP705/SP705-iphone_6-mul.png",                   ["iPhone7,2"],                                4.7,  (9, 16),  "iPhone 6", 326, False, False, False, False, True, False, False),
+            Device("iPhone6Plus",     "Device is an [iPhone 6 Plus](https://support.apple.com/kb/SP706)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP706/SP706-iphone_6_plus-mul.png",              ["iPhone7,1"],                                5.5,  (9, 16),  "iPhone 6 Plus", 401, True, False, False, False, True, False, False),
+            Device("iPhone6s",        "Device is an [iPhone 6s](https://support.apple.com/kb/SP726)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP726/SP726-iphone6s-gray-select-2015.png",      ["iPhone8,1"],                                4.7,  (9, 16),  "iPhone 6s", 326, False, False, False, False, True, False, False),
+            Device("iPhone6sPlus",    "Device is an [iPhone 6s Plus](https://support.apple.com/kb/SP727)",              "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP727/SP727-iphone6s-plus-gray-select-2015.png", ["iPhone8,2"],                                5.5,  (9, 16),  "iPhone 6s Plus", 401, True, False, False, False, True, False, False),
+            Device("iPhone7",         "Device is an [iPhone 7](https://support.apple.com/kb/SP743)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP743/iphone7-black.png",                        ["iPhone9,1", "iPhone9,3"],                   4.7,  (9, 16),  "iPhone 7", 326, False, False, False, False, True, False, False),
+            Device("iPhone7Plus",     "Device is an [iPhone 7 Plus](https://support.apple.com/kb/SP744)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP744/iphone7-plus-black.png",                   ["iPhone9,2", "iPhone9,4"],                   5.5,  (9, 16),  "iPhone 7 Plus", 401, True, False, False, False, True, False, False),
+            Device("iPhoneSE",        "Device is an [iPhone SE](https://support.apple.com/kb/SP738)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP738/SP738.png",                                ["iPhone8,4"],                                4,    (9, 16),  "iPhone SE", 326, False, False, False, False, True, False, False),
+            Device("iPhone8",         "Device is an [iPhone 8](https://support.apple.com/kb/SP767)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP767/iphone8.png",                              ["iPhone10,1", "iPhone10,4"],                 4.7,  (9, 16),  "iPhone 8", 326, False, False, False, False, True, False, False),
+            Device("iPhone8Plus",     "Device is an [iPhone 8 Plus](https://support.apple.com/kb/SP768)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP768/iphone8plus.png",                          ["iPhone10,2", "iPhone10,5"],                 5.5,  (9, 16),  "iPhone 8 Plus", 401, True, False, False, False, True, False, False),
+            Device("iPhoneX",         "Device is an [iPhone X](https://support.apple.com/kb/SP770)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP770/iphonex.png",                              ["iPhone10,3", "iPhone10,6"],                 5.8,  (9, 19.5),  "iPhone X", 458, False, False, False, True, False, True, False),
+            Device("iPhoneXs",        "Device is an [iPhone Xs](https://support.apple.com/kb/SP779)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP779/SP779-iphone-xs.jpg",                      ["iPhone11,2"],                               5.8,  (9, 19.5),  "iPhone Xs", 458, False, False, False, True, False, True, False),
+            Device("iPhoneXsMax",     "Device is an [iPhone Xs Max](https://support.apple.com/kb/SP780)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP780/SP780-iPhone-Xs-Max.jpg",                  ["iPhone11,4", "iPhone11,6"],                 6.5,  (9, 19.5),  "iPhone Xs Max", 458, False, False, False, True, False, True, False),
+            Device("iPhoneXr",        "Device is an [iPhone Xr](https://support.apple.com/kb/SP781)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP781/SP781-iPhone-xr.jpg",                      ["iPhone11,8"],                               6.1,  (9, 19.5),  "iPhone Xr", 326, False, False, False, True, False, True, False)
           ]
 
 iPads = [
-            Device("iPad2",           "Device is an [iPad 2](https://support.apple.com/kb/SP622)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP622/SP622_01-ipad2-mul.png",                   ["iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4"], 9.7,  (3, 4),   "iPad 2", 132, False, False, False, False, False, False),
-            Device("iPad3",           "Device is an [iPad (3rd generation)](https://support.apple.com/kb/SP647)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,1", "iPad3,2", "iPad3,3"],            9.7,  (3, 4),   "iPad 3", 264, False, False, False, False, False, False),
-            Device("iPad4",           "Device is an [iPad (4th generation)](https://support.apple.com/kb/SP662)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,4", "iPad3,5", "iPad3,6"],            9.7,  (3, 4),   "iPad 4", 264, False, False, False, False, False, False),
-            Device("iPadAir",         "Device is an [iPad Air](https://support.apple.com/kb/SP692)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP692/SP692-specs_color-mul.png",                ["iPad4,1", "iPad4,2", "iPad4,3"],            9.7,  (3, 4),   "iPad Air", 264, False, False, False, False, False, False),
-            Device("iPadAir2",        "Device is an [iPad Air 2](https://support.apple.com/kb/SP708)",                  "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP708/SP708-space_gray.jpeg",                    ["iPad5,3", "iPad5,4"],                       9.7,  (3, 4),   "iPad Air 2", 264, False, False, False, False, True, False),
-            Device("iPad5",           "Device is an [iPad 5](https://support.apple.com/kb/SP751)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad6,11", "iPad6,12"],                     9.7,  (3, 4),   "iPad 5", 264, False, False, False, False, True, False),
-            Device("iPad6",           "Device is an [iPad 6](https://support.apple.com/kb/NotYetAvailable)",            "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad7,5", "iPad7,6"],                       9.7,  (3, 4),   "iPad 6", 264, False, False, False, False, True, False),
-            Device("iPadAir3",        "Device is an [iPad Air (3rd generation)](INSERT LINK)",                          "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/mini/ipad-mini-compare-201903", ["iPad11,3", "iPad11,4"],       10.5, (3, 4),   "iPad Air (3rd generation)", 264, False, False, False, False, True, False),
-            Device("iPadMini",        "Device is an [iPad Mini](https://support.apple.com/kb/SP661)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP661/sp661_ipad_mini_color.jpg",                ["iPad2,5", "iPad2,6", "iPad2,7"],            7.9,  (3, 4),   "iPad Mini", 163, False, True, False, False, False, False),
-            Device("iPadMini2",       "Device is an [iPad Mini 2](https://support.apple.com/kb/SP693)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP693/SP693-specs_color-mul.png",                ["iPad4,4", "iPad4,5", "iPad4,6"],            7.9,  (3, 4),   "iPad Mini 2", 326, False, True, False, False, False, False),
-            Device("iPadMini3",       "Device is an [iPad Mini 3](https://support.apple.com/kb/SP709)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP709/SP709-space_gray.jpeg",                    ["iPad4,7", "iPad4,8", "iPad4,9"],            7.9,  (3, 4),   "iPad Mini 3", 326, False, True, False, False, True, False),
-            Device("iPadMini4",       "Device is an [iPad Mini 4](https://support.apple.com/kb/SP725)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP725/SP725ipad-mini-4.png",                     ["iPad5,1", "iPad5,2"],                       7.9,  (3, 4),   "iPad Mini 4", 326, False, True, False, False, True, False),
-            Device("iPadMini5",       "Device is an [iPad Mini (5th generation)](INSERT LINK)",                         "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/air/ipad-air-compare-201903", ["iPad11,1", "iPad11,2"],    7.9,  (3, 4),   "iPad Mini (5th generation)", 326, False, True, False, False, True, False),
-            Device("iPadPro9Inch",    "Device is an [iPad Pro 9.7-inch](https://support.apple.com/kb/SP739)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP739/SP739.png",                                ["iPad6,3", "iPad6,4"],                       9.7,  (3, 4),   "iPad Pro (9.7-inch)", 264, False, False, True, False, True, False),
-            Device("iPadPro12Inch",   "Device is an [iPad Pro 12-inch](https://support.apple.com/kb/sp723)",                    "http://images.apple.com/v/ipad-pro/c/images/shared/buystrip/ipad_pro_large_2x.png",                        ["iPad6,7", "iPad6,8"],                       12.9, (3, 4),   "iPad Pro (12.9-inch)", 264, False, False, True, False, True, False),
-            Device("iPadPro12Inch2",  "Device is an [iPad Pro 12-inch (2nd generation)](https://support.apple.com/kb/SP761)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-12in-hero-201706.png",            ["iPad7,1", "iPad7,2"],                       12.9, (3, 4),   "iPad Pro (12.9-inch) (2nd generation)", 264, False, False, True, False, True, False),
-            Device("iPadPro10Inch",   "Device is an [iPad Pro 10.5-inch](https://support.apple.com/kb/SP762)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-10in-hero-201706.png",            ["iPad7,3", "iPad7,4"],                       10.5, (3, 4),   "iPad Pro (10.5-inch)", 264, False, False, True, False, True, False),
-            Device("iPadPro11Inch",   "Device is an [iPad Pro 11-inch](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4"],                       11.0, (139, 199),   "iPad Pro (11-inch)", 264, False, False, True, False, False, True),
-            Device("iPadPro12Inch3",   "Device is an [iPad Pro 12.9-inch (3rd generation)](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8"],                       12.9, (512, 683),   "iPad Pro (12.9-inch) (3rd generation)", 264, False, False, True, False, False, True)
+            Device("iPad2",           "Device is an [iPad 2](https://support.apple.com/kb/SP622)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP622/SP622_01-ipad2-mul.png",                   ["iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4"], 9.7,  (3, 4),   "iPad 2", 132, False, False, False, False, False, False, False),
+            Device("iPad3",           "Device is an [iPad (3rd generation)](https://support.apple.com/kb/SP647)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,1", "iPad3,2", "iPad3,3"],            9.7,  (3, 4),   "iPad 3", 264, False, False, False, False, False, False, False),
+            Device("iPad4",           "Device is an [iPad (4th generation)](https://support.apple.com/kb/SP662)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,4", "iPad3,5", "iPad3,6"],            9.7,  (3, 4),   "iPad 4", 264, False, False, False, False, False, False, False),
+            Device("iPadAir",         "Device is an [iPad Air](https://support.apple.com/kb/SP692)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP692/SP692-specs_color-mul.png",                ["iPad4,1", "iPad4,2", "iPad4,3"],            9.7,  (3, 4),   "iPad Air", 264, False, False, False, False, False, False, False),
+            Device("iPadAir2",        "Device is an [iPad Air 2](https://support.apple.com/kb/SP708)",                  "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP708/SP708-space_gray.jpeg",                    ["iPad5,3", "iPad5,4"],                       9.7,  (3, 4),   "iPad Air 2", 264, False, False, False, False, True, False, False),
+            Device("iPad5",           "Device is an [iPad 5](https://support.apple.com/kb/SP751)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad6,11", "iPad6,12"],                     9.7,  (3, 4),   "iPad 5", 264, False, False, False, False, True, False, False),
+            Device("iPad6",           "Device is an [iPad 6](https://support.apple.com/kb/NotYetAvailable)",            "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad7,5", "iPad7,6"],                       9.7,  (3, 4),   "iPad 6", 264, False, False, False, False, True, False, True),
+            Device("iPadAir3",        "Device is an [iPad Air (3rd generation)](INSERT LINK)",                          "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/mini/ipad-mini-compare-201903", ["iPad11,3", "iPad11,4"],       10.5, (3, 4),   "iPad Air (3rd generation)", 264, False, False, False, False, True, False, True),
+            Device("iPadMini",        "Device is an [iPad Mini](https://support.apple.com/kb/SP661)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP661/sp661_ipad_mini_color.jpg",                ["iPad2,5", "iPad2,6", "iPad2,7"],            7.9,  (3, 4),   "iPad Mini", 163, False, True, False, False, False, False, False),
+            Device("iPadMini2",       "Device is an [iPad Mini 2](https://support.apple.com/kb/SP693)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP693/SP693-specs_color-mul.png",                ["iPad4,4", "iPad4,5", "iPad4,6"],            7.9,  (3, 4),   "iPad Mini 2", 326, False, True, False, False, False, False, False),
+            Device("iPadMini3",       "Device is an [iPad Mini 3](https://support.apple.com/kb/SP709)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP709/SP709-space_gray.jpeg",                    ["iPad4,7", "iPad4,8", "iPad4,9"],            7.9,  (3, 4),   "iPad Mini 3", 326, False, True, False, False, True, False, False),
+            Device("iPadMini4",       "Device is an [iPad Mini 4](https://support.apple.com/kb/SP725)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP725/SP725ipad-mini-4.png",                     ["iPad5,1", "iPad5,2"],                       7.9,  (3, 4),   "iPad Mini 4", 326, False, True, False, False, True, False, False),
+            Device("iPadMini5",       "Device is an [iPad Mini (5th generation)](INSERT LINK)",                         "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/air/ipad-air-compare-201903", ["iPad11,1", "iPad11,2"],    7.9,  (3, 4),   "iPad Mini (5th generation)", 326, False, True, False, False, True, False, True),
+            Device("iPadPro9Inch",    "Device is an [iPad Pro 9.7-inch](https://support.apple.com/kb/SP739)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP739/SP739.png",                                ["iPad6,3", "iPad6,4"],                       9.7,  (3, 4),   "iPad Pro (9.7-inch)", 264, False, False, True, False, True, False, True),
+            Device("iPadPro12Inch",   "Device is an [iPad Pro 12-inch](https://support.apple.com/kb/sp723)",                    "http://images.apple.com/v/ipad-pro/c/images/shared/buystrip/ipad_pro_large_2x.png",                        ["iPad6,7", "iPad6,8"],                       12.9, (3, 4),   "iPad Pro (12.9-inch)", 264, False, False, True, False, True, False, True),
+            Device("iPadPro12Inch2",  "Device is an [iPad Pro 12-inch (2nd generation)](https://support.apple.com/kb/SP761)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-12in-hero-201706.png",            ["iPad7,1", "iPad7,2"],                       12.9, (3, 4),   "iPad Pro (12.9-inch) (2nd generation)", 264, False, False, True, False, True, False, True),
+            Device("iPadPro10Inch",   "Device is an [iPad Pro 10.5-inch](https://support.apple.com/kb/SP762)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-10in-hero-201706.png",            ["iPad7,3", "iPad7,4"],                       10.5, (3, 4),   "iPad Pro (10.5-inch)", 264, False, False, True, False, True, False, True),
+            Device("iPadPro11Inch",   "Device is an [iPad Pro 11-inch](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4"],                       11.0, (139, 199),   "iPad Pro (11-inch)", 264, False, False, True, False, False, True, True),
+            Device("iPadPro12Inch3",   "Device is an [iPad Pro 12.9-inch (3rd generation)](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8"],                       12.9, (512, 683),   "iPad Pro (12.9-inch) (3rd generation)", 264, False, False, True, False, False, True, True)
 
         ]
 
 homePods =  [
-            Device("homePod",         "Device is a [HomePod](https://www.apple.com/homepod/)",                          "https://images.apple.com/v/homepod/d/images/overview/homepod_side_dark_large_2x.jpg",                     ["AudioAccessory1,1"], -1,  (4, 5),   "HomePod", -1, False, False, False, False, False, False),
+            Device("homePod",         "Device is a [HomePod](https://www.apple.com/homepod/)",                          "https://images.apple.com/v/homepod/d/images/overview/homepod_side_dark_large_2x.jpg",                     ["AudioAccessory1,1"], -1,  (4, 5),   "HomePod", -1, False, False, False, False, False, False, False),
             ]
 # tvOS
 tvs = [
-            Device("appleTV4",        "Device is an [Apple TV 4](https://support.apple.com/kb/SP724)",                  "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                                       ["AppleTV5,3"],                               0,    (),       "Apple TV 4", -1, False, False, False, False, False, False),
-            Device("appleTV4K",       "Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png",                            ["AppleTV6,2"],                               0,    (),       "Apple TV 4K", -1, False, False, False, False, False, False)
+            Device("appleTV4",        "Device is an [Apple TV 4](https://support.apple.com/kb/SP724)",                  "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                                       ["AppleTV5,3"],                               0,    (),       "Apple TV 4", -1, False, False, False, False, False, False, False),
+            Device("appleTV4K",       "Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png",                            ["AppleTV6,2"],                               0,    (),       "Apple TV 4K", -1, False, False, False, False, False, False, False)
       ]
 
 # watchOS
@@ -93,70 +94,70 @@ watches = [
             "appleWatchSeries0_38mm",
             "Device is an [Apple Watch (1st generation)](https://support.apple.com/kb/SP735)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM784/en_US/apple_watch_sport-240.png",
-            ["Watch1,1"], 1.5, (4,5), "Apple Watch (1st generation) 38mm", 290, False, False, False, False, False, False),
+            ["Watch1,1"], 1.5, (4,5), "Apple Watch (1st generation) 38mm", 290, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries0_42mm",
             "Device is an [Apple Watch (1st generation)](https://support.apple.com/kb/SP735)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM784/en_US/apple_watch_sport-240.png",
-            ["Watch1,2"], 1.6, (4,5), "Apple Watch (1st generation) 42mm", 303, False, False, False, False, False, False),
+            ["Watch1,2"], 1.6, (4,5), "Apple Watch (1st generation) 42mm", 303, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries1_38mm",
             "Device is an [Apple Watch Series 1](https://support.apple.com/kb/SP745)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM848/en_US/applewatch-series2-aluminum-temp-240.png",
-            ["Watch2,6"], 1.5, (4,5), "Apple Watch Series 1 38mm", 290, False, False, False, False, False, False),
+            ["Watch2,6"], 1.5, (4,5), "Apple Watch Series 1 38mm", 290, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries1_42mm",
             "Device is an [Apple Watch Series 1](https://support.apple.com/kb/SP745)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM848/en_US/applewatch-series2-aluminum-temp-240.png",
-            ["Watch2,7"], 1.6, (4,5), "Apple Watch Series 1 42mm", 303, False, False, False, False, False, False),
+            ["Watch2,7"], 1.6, (4,5), "Apple Watch Series 1 42mm", 303, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries2_38mm",
             "Device is an [Apple Watch Series 2](https://support.apple.com/kb/SP746)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM852/en_US/applewatch-series2-hermes-240.png",
-            ["Watch2,3"], 1.5, (4,5), "Apple Watch Series 2 38mm", 290, False, False, False, False, False, False),
+            ["Watch2,3"], 1.5, (4,5), "Apple Watch Series 2 38mm", 290, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries2_42mm",
             "Device is an [Apple Watch Series 2](https://support.apple.com/kb/SP746)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM852/en_US/applewatch-series2-hermes-240.png",
-            ["Watch2,4"], 1.6, (4,5), "Apple Watch Series 2 42mm", 303, False, False, False, False, False, False),
+            ["Watch2,4"], 1.6, (4,5), "Apple Watch Series 2 42mm", 303, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries3_38mm",
             "Device is an [Apple Watch Series 3](https://support.apple.com/kb/SP766)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM893/en_US/apple-watch-s3-nikeplus-240.png",
-            ["Watch3,1", "Watch3,3"], 1.5, (4,5), "Apple Watch Series 3 38mm", 290, False, False, False, False, False, False),
+            ["Watch3,1", "Watch3,3"], 1.5, (4,5), "Apple Watch Series 3 38mm", 290, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries3_42mm",
             "Device is an [Apple Watch Series 3](https://support.apple.com/kb/SP766)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM893/en_US/apple-watch-s3-nikeplus-240.png",
-            ["Watch3,2", "Watch3,4"], 1.6, (4,5), "Apple Watch Series 3 42mm", 303, False, False, False, False, False, False),
+            ["Watch3,2", "Watch3,4"], 1.6, (4,5), "Apple Watch Series 3 42mm", 303, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries4_40mm",
             "Device is an [Apple Watch Series 4](https://support.apple.com/kb/SP778)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM911/en_US/aw-series4-nike-240.png",
-            ["Watch4,1", "Watch4,3"], 1.8, (4,5), "Apple Watch Series 4 40mm", 326, False, False, False, False, False, False),
+            ["Watch4,1", "Watch4,3"], 1.8, (4,5), "Apple Watch Series 4 40mm", 326, False, False, False, False, False, False, False),
 
 
             Device(
             "appleWatchSeries4_44mm",
             "Device is an [Apple Watch Series 4](https://support.apple.com/kb/SP778)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM911/en_US/aw-series4-nike-240.png",
-            ["Watch4,2", "Watch4,4"], 2.0, (4,5), "Apple Watch Series 4 44mm", 326, False, False, False, False, False, False),
+            ["Watch4,2", "Watch4,4"], 2.0, (4,5), "Apple Watch Series 4 44mm", 326, False, False, False, False, False, False, False),
   ]
 
 iOSDevices = iPods + iPhones + iPads + homePods
@@ -471,6 +472,11 @@ public enum Device {
       return [${', '.join(list(map(lambda device: "." + device.caseName, list(filter(lambda device: device.hasFaceID == True, iOSDevices)))))}]
     }
 
+    /// All Apple Pencil Capable Devices
+    public static var allApplePencilCapableDevices: [Device] {
+      return [${', '.join(list(map(lambda device: "." + device.caseName, list(filter(lambda device: device.hasApplePencil == True, iOSDevices)))))}]
+    }
+
     /// Returns whether or not the device has Touch ID
     public var isTouchIDCapable: Bool {
       return isOneOf(Device.allTouchIDCapableDevices)
@@ -486,6 +492,10 @@ public enum Device {
       return isTouchIDCapable || isFaceIDCapable
     }
 
+    /// Returns whether or not the device is compatible with Apple Pencil
+    public var isApplePencilCapable: Bool {
+      return isOneOf(Device.allApplePencilCapableDevices)
+    }
   #elseif os(tvOS)
     /// All TVs
     public static var allTVs: [Device] {

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -12,7 +12,7 @@
 %{
 class Device:
 
-  def __init__(self, caseName, comment, imageURL, identifiers, diagonal, screenRatio, description, ppi, isPlusFormFactor, isPadMiniFormFactor, isPro, isXSeries, hasTouchID, hasFaceID, hasApplePencil):
+  def __init__(self, caseName, comment, imageURL, identifiers, diagonal, screenRatio, description, ppi, isPlusFormFactor, isPadMiniFormFactor, isPro, isXSeries, hasTouchID, hasFaceID, applePencilSupport):
     self.caseName = caseName
     self.comment = comment
     self.imageURL = imageURL
@@ -27,65 +27,65 @@ class Device:
     self.isXSeries = isXSeries
     self.hasTouchID = hasTouchID
     self.hasFaceID = hasFaceID
-    self.hasApplePencil = hasApplePencil
+    self.applePencilSupport = applePencilSupport
 
 # iOS
 iPods = [
-            Device("iPodTouch5",      "Device is an [iPod Touch (5th generation)](https://support.apple.com/kb/SP657)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP657/sp657_ipod-touch_size.jpg",                ["iPod5,1"],                                  4,    (9, 16),  "iPod Touch 5", 326, False, False, False, False, False, False, False),
-            Device("iPodTouch6",      "Device is an [iPod Touch (6th generation)](https://support.apple.com/kb/SP720)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP720/SP720-ipod-touch-specs-color-sg-2015.jpg", ["iPod7,1"],                                  4,    (9, 16),  "iPod Touch 6", 326, False, False, False, False, False, False, False)
+            Device("iPodTouch5",      "Device is an [iPod Touch (5th generation)](https://support.apple.com/kb/SP657)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP657/sp657_ipod-touch_size.jpg",                ["iPod5,1"],                                  4,    (9, 16),  "iPod Touch 5", 326, False, False, False, False, False, False, 0),
+            Device("iPodTouch6",      "Device is an [iPod Touch (6th generation)](https://support.apple.com/kb/SP720)", "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP720/SP720-ipod-touch-specs-color-sg-2015.jpg", ["iPod7,1"],                                  4,    (9, 16),  "iPod Touch 6", 326, False, False, False, False, False, False, 0)
         ]
 
 iPhones = [
-            Device("iPhone4",         "Device is an [iPhone 4](https://support.apple.com/kb/SP587)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP643/sp643_iphone4s_color_black.jpg",           ["iPhone3,1", "iPhone3,2", "iPhone3,3"],      3.5,  (2, 3),   "iPhone 4", 326, False, False, False, False, False, False, False),
-            Device("iPhone4s",        "Device is an [iPhone 4s](https://support.apple.com/kb/SP643)",                   "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone5s/iphone_4s.png",  ["iPhone4,1"],                                3.5,  (2, 3),   "iPhone 4s", 326, False, False, False, False, False, False, False),
-            Device("iPhone5",         "Device is an [iPhone 5](https://support.apple.com/kb/SP655)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP655/sp655_iphone5_color.jpg",                  ["iPhone5,1", "iPhone5,2"],                   4,    (9, 16),  "iPhone 5", 326, False, False, False, False, False, False, False),
-            Device("iPhone5c",        "Device is an [iPhone 5c](https://support.apple.com/kb/SP684)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP684/SP684-color_yellow.jpg",                   ["iPhone5,3", "iPhone5,4"],                   4,    (9, 16),  "iPhone 5c", 326, False, False, False, False, False, False, False),
-            Device("iPhone5s",        "Device is an [iPhone 5s](https://support.apple.com/kb/SP685)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP685/SP685-color_black.jpg",                    ["iPhone6,1", "iPhone6,2"],                   4,    (9, 16),  "iPhone 5s", 326, False, False, False, False, True, False, False),
-            Device("iPhone6",         "Device is an [iPhone 6](https://support.apple.com/kb/SP705)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP705/SP705-iphone_6-mul.png",                   ["iPhone7,2"],                                4.7,  (9, 16),  "iPhone 6", 326, False, False, False, False, True, False, False),
-            Device("iPhone6Plus",     "Device is an [iPhone 6 Plus](https://support.apple.com/kb/SP706)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP706/SP706-iphone_6_plus-mul.png",              ["iPhone7,1"],                                5.5,  (9, 16),  "iPhone 6 Plus", 401, True, False, False, False, True, False, False),
-            Device("iPhone6s",        "Device is an [iPhone 6s](https://support.apple.com/kb/SP726)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP726/SP726-iphone6s-gray-select-2015.png",      ["iPhone8,1"],                                4.7,  (9, 16),  "iPhone 6s", 326, False, False, False, False, True, False, False),
-            Device("iPhone6sPlus",    "Device is an [iPhone 6s Plus](https://support.apple.com/kb/SP727)",              "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP727/SP727-iphone6s-plus-gray-select-2015.png", ["iPhone8,2"],                                5.5,  (9, 16),  "iPhone 6s Plus", 401, True, False, False, False, True, False, False),
-            Device("iPhone7",         "Device is an [iPhone 7](https://support.apple.com/kb/SP743)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP743/iphone7-black.png",                        ["iPhone9,1", "iPhone9,3"],                   4.7,  (9, 16),  "iPhone 7", 326, False, False, False, False, True, False, False),
-            Device("iPhone7Plus",     "Device is an [iPhone 7 Plus](https://support.apple.com/kb/SP744)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP744/iphone7-plus-black.png",                   ["iPhone9,2", "iPhone9,4"],                   5.5,  (9, 16),  "iPhone 7 Plus", 401, True, False, False, False, True, False, False),
-            Device("iPhoneSE",        "Device is an [iPhone SE](https://support.apple.com/kb/SP738)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP738/SP738.png",                                ["iPhone8,4"],                                4,    (9, 16),  "iPhone SE", 326, False, False, False, False, True, False, False),
-            Device("iPhone8",         "Device is an [iPhone 8](https://support.apple.com/kb/SP767)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP767/iphone8.png",                              ["iPhone10,1", "iPhone10,4"],                 4.7,  (9, 16),  "iPhone 8", 326, False, False, False, False, True, False, False),
-            Device("iPhone8Plus",     "Device is an [iPhone 8 Plus](https://support.apple.com/kb/SP768)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP768/iphone8plus.png",                          ["iPhone10,2", "iPhone10,5"],                 5.5,  (9, 16),  "iPhone 8 Plus", 401, True, False, False, False, True, False, False),
-            Device("iPhoneX",         "Device is an [iPhone X](https://support.apple.com/kb/SP770)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP770/iphonex.png",                              ["iPhone10,3", "iPhone10,6"],                 5.8,  (9, 19.5),  "iPhone X", 458, False, False, False, True, False, True, False),
-            Device("iPhoneXs",        "Device is an [iPhone Xs](https://support.apple.com/kb/SP779)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP779/SP779-iphone-xs.jpg",                      ["iPhone11,2"],                               5.8,  (9, 19.5),  "iPhone Xs", 458, False, False, False, True, False, True, False),
-            Device("iPhoneXsMax",     "Device is an [iPhone Xs Max](https://support.apple.com/kb/SP780)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP780/SP780-iPhone-Xs-Max.jpg",                  ["iPhone11,4", "iPhone11,6"],                 6.5,  (9, 19.5),  "iPhone Xs Max", 458, False, False, False, True, False, True, False),
-            Device("iPhoneXr",        "Device is an [iPhone Xr](https://support.apple.com/kb/SP781)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP781/SP781-iPhone-xr.jpg",                      ["iPhone11,8"],                               6.1,  (9, 19.5),  "iPhone Xr", 326, False, False, False, True, False, True, False)
+            Device("iPhone4",         "Device is an [iPhone 4](https://support.apple.com/kb/SP587)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP643/sp643_iphone4s_color_black.jpg",           ["iPhone3,1", "iPhone3,2", "iPhone3,3"],      3.5,  (2, 3),   "iPhone 4", 326, False, False, False, False, False, False, 0),
+            Device("iPhone4s",        "Device is an [iPhone 4s](https://support.apple.com/kb/SP643)",                   "https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone5s/iphone_4s.png",  ["iPhone4,1"],                                3.5,  (2, 3),   "iPhone 4s", 326, False, False, False, False, False, False, 0),
+            Device("iPhone5",         "Device is an [iPhone 5](https://support.apple.com/kb/SP655)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP655/sp655_iphone5_color.jpg",                  ["iPhone5,1", "iPhone5,2"],                   4,    (9, 16),  "iPhone 5", 326, False, False, False, False, False, False, 0),
+            Device("iPhone5c",        "Device is an [iPhone 5c](https://support.apple.com/kb/SP684)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP684/SP684-color_yellow.jpg",                   ["iPhone5,3", "iPhone5,4"],                   4,    (9, 16),  "iPhone 5c", 326, False, False, False, False, False, False, 0),
+            Device("iPhone5s",        "Device is an [iPhone 5s](https://support.apple.com/kb/SP685)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP685/SP685-color_black.jpg",                    ["iPhone6,1", "iPhone6,2"],                   4,    (9, 16),  "iPhone 5s", 326, False, False, False, False, True, False, 0),
+            Device("iPhone6",         "Device is an [iPhone 6](https://support.apple.com/kb/SP705)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP705/SP705-iphone_6-mul.png",                   ["iPhone7,2"],                                4.7,  (9, 16),  "iPhone 6", 326, False, False, False, False, True, False, 0),
+            Device("iPhone6Plus",     "Device is an [iPhone 6 Plus](https://support.apple.com/kb/SP706)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP706/SP706-iphone_6_plus-mul.png",              ["iPhone7,1"],                                5.5,  (9, 16),  "iPhone 6 Plus", 401, True, False, False, False, True, False, 0),
+            Device("iPhone6s",        "Device is an [iPhone 6s](https://support.apple.com/kb/SP726)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP726/SP726-iphone6s-gray-select-2015.png",      ["iPhone8,1"],                                4.7,  (9, 16),  "iPhone 6s", 326, False, False, False, False, True, False, 0),
+            Device("iPhone6sPlus",    "Device is an [iPhone 6s Plus](https://support.apple.com/kb/SP727)",              "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP727/SP727-iphone6s-plus-gray-select-2015.png", ["iPhone8,2"],                                5.5,  (9, 16),  "iPhone 6s Plus", 401, True, False, False, False, True, False, 0),
+            Device("iPhone7",         "Device is an [iPhone 7](https://support.apple.com/kb/SP743)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP743/iphone7-black.png",                        ["iPhone9,1", "iPhone9,3"],                   4.7,  (9, 16),  "iPhone 7", 326, False, False, False, False, True, False, 0),
+            Device("iPhone7Plus",     "Device is an [iPhone 7 Plus](https://support.apple.com/kb/SP744)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP744/iphone7-plus-black.png",                   ["iPhone9,2", "iPhone9,4"],                   5.5,  (9, 16),  "iPhone 7 Plus", 401, True, False, False, False, True, False, 0),
+            Device("iPhoneSE",        "Device is an [iPhone SE](https://support.apple.com/kb/SP738)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP738/SP738.png",                                ["iPhone8,4"],                                4,    (9, 16),  "iPhone SE", 326, False, False, False, False, True, False, 0),
+            Device("iPhone8",         "Device is an [iPhone 8](https://support.apple.com/kb/SP767)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP767/iphone8.png",                              ["iPhone10,1", "iPhone10,4"],                 4.7,  (9, 16),  "iPhone 8", 326, False, False, False, False, True, False, 0),
+            Device("iPhone8Plus",     "Device is an [iPhone 8 Plus](https://support.apple.com/kb/SP768)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP768/iphone8plus.png",                          ["iPhone10,2", "iPhone10,5"],                 5.5,  (9, 16),  "iPhone 8 Plus", 401, True, False, False, False, True, False, 0),
+            Device("iPhoneX",         "Device is an [iPhone X](https://support.apple.com/kb/SP770)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP770/iphonex.png",                              ["iPhone10,3", "iPhone10,6"],                 5.8,  (9, 19.5),  "iPhone X", 458, False, False, False, True, False, True, 0),
+            Device("iPhoneXs",        "Device is an [iPhone Xs](https://support.apple.com/kb/SP779)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP779/SP779-iphone-xs.jpg",                      ["iPhone11,2"],                               5.8,  (9, 19.5),  "iPhone Xs", 458, False, False, False, True, False, True, 0),
+            Device("iPhoneXsMax",     "Device is an [iPhone Xs Max](https://support.apple.com/kb/SP780)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP780/SP780-iPhone-Xs-Max.jpg",                  ["iPhone11,4", "iPhone11,6"],                 6.5,  (9, 19.5),  "iPhone Xs Max", 458, False, False, False, True, False, True, 0),
+            Device("iPhoneXr",        "Device is an [iPhone Xr](https://support.apple.com/kb/SP781)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP781/SP781-iPhone-xr.jpg",                      ["iPhone11,8"],                               6.1,  (9, 19.5),  "iPhone Xr", 326, False, False, False, True, False, True, 0)
           ]
 
 iPads = [
-            Device("iPad2",           "Device is an [iPad 2](https://support.apple.com/kb/SP622)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP622/SP622_01-ipad2-mul.png",                   ["iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4"], 9.7,  (3, 4),   "iPad 2", 132, False, False, False, False, False, False, False),
-            Device("iPad3",           "Device is an [iPad (3rd generation)](https://support.apple.com/kb/SP647)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,1", "iPad3,2", "iPad3,3"],            9.7,  (3, 4),   "iPad 3", 264, False, False, False, False, False, False, False),
-            Device("iPad4",           "Device is an [iPad (4th generation)](https://support.apple.com/kb/SP662)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,4", "iPad3,5", "iPad3,6"],            9.7,  (3, 4),   "iPad 4", 264, False, False, False, False, False, False, False),
-            Device("iPadAir",         "Device is an [iPad Air](https://support.apple.com/kb/SP692)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP692/SP692-specs_color-mul.png",                ["iPad4,1", "iPad4,2", "iPad4,3"],            9.7,  (3, 4),   "iPad Air", 264, False, False, False, False, False, False, False),
-            Device("iPadAir2",        "Device is an [iPad Air 2](https://support.apple.com/kb/SP708)",                  "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP708/SP708-space_gray.jpeg",                    ["iPad5,3", "iPad5,4"],                       9.7,  (3, 4),   "iPad Air 2", 264, False, False, False, False, True, False, False),
-            Device("iPad5",           "Device is an [iPad 5](https://support.apple.com/kb/SP751)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad6,11", "iPad6,12"],                     9.7,  (3, 4),   "iPad 5", 264, False, False, False, False, True, False, False),
-            Device("iPad6",           "Device is an [iPad 6](https://support.apple.com/kb/NotYetAvailable)",            "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad7,5", "iPad7,6"],                       9.7,  (3, 4),   "iPad 6", 264, False, False, False, False, True, False, True),
-            Device("iPadAir3",        "Device is an [iPad Air (3rd generation)](INSERT LINK)",                          "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/mini/ipad-mini-compare-201903", ["iPad11,3", "iPad11,4"],       10.5, (3, 4),   "iPad Air (3rd generation)", 264, False, False, False, False, True, False, True),
-            Device("iPadMini",        "Device is an [iPad Mini](https://support.apple.com/kb/SP661)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP661/sp661_ipad_mini_color.jpg",                ["iPad2,5", "iPad2,6", "iPad2,7"],            7.9,  (3, 4),   "iPad Mini", 163, False, True, False, False, False, False, False),
-            Device("iPadMini2",       "Device is an [iPad Mini 2](https://support.apple.com/kb/SP693)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP693/SP693-specs_color-mul.png",                ["iPad4,4", "iPad4,5", "iPad4,6"],            7.9,  (3, 4),   "iPad Mini 2", 326, False, True, False, False, False, False, False),
-            Device("iPadMini3",       "Device is an [iPad Mini 3](https://support.apple.com/kb/SP709)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP709/SP709-space_gray.jpeg",                    ["iPad4,7", "iPad4,8", "iPad4,9"],            7.9,  (3, 4),   "iPad Mini 3", 326, False, True, False, False, True, False, False),
-            Device("iPadMini4",       "Device is an [iPad Mini 4](https://support.apple.com/kb/SP725)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP725/SP725ipad-mini-4.png",                     ["iPad5,1", "iPad5,2"],                       7.9,  (3, 4),   "iPad Mini 4", 326, False, True, False, False, True, False, False),
-            Device("iPadMini5",       "Device is an [iPad Mini (5th generation)](INSERT LINK)",                         "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/air/ipad-air-compare-201903", ["iPad11,1", "iPad11,2"],    7.9,  (3, 4),   "iPad Mini (5th generation)", 326, False, True, False, False, True, False, True),
-            Device("iPadPro9Inch",    "Device is an [iPad Pro 9.7-inch](https://support.apple.com/kb/SP739)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP739/SP739.png",                                ["iPad6,3", "iPad6,4"],                       9.7,  (3, 4),   "iPad Pro (9.7-inch)", 264, False, False, True, False, True, False, True),
-            Device("iPadPro12Inch",   "Device is an [iPad Pro 12-inch](https://support.apple.com/kb/sp723)",                    "http://images.apple.com/v/ipad-pro/c/images/shared/buystrip/ipad_pro_large_2x.png",                        ["iPad6,7", "iPad6,8"],                       12.9, (3, 4),   "iPad Pro (12.9-inch)", 264, False, False, True, False, True, False, True),
-            Device("iPadPro12Inch2",  "Device is an [iPad Pro 12-inch (2nd generation)](https://support.apple.com/kb/SP761)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-12in-hero-201706.png",            ["iPad7,1", "iPad7,2"],                       12.9, (3, 4),   "iPad Pro (12.9-inch) (2nd generation)", 264, False, False, True, False, True, False, True),
-            Device("iPadPro10Inch",   "Device is an [iPad Pro 10.5-inch](https://support.apple.com/kb/SP762)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-10in-hero-201706.png",            ["iPad7,3", "iPad7,4"],                       10.5, (3, 4),   "iPad Pro (10.5-inch)", 264, False, False, True, False, True, False, True),
-            Device("iPadPro11Inch",   "Device is an [iPad Pro 11-inch](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4"],                       11.0, (139, 199),   "iPad Pro (11-inch)", 264, False, False, True, False, False, True, True),
-            Device("iPadPro12Inch3",   "Device is an [iPad Pro 12.9-inch (3rd generation)](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8"],                       12.9, (512, 683),   "iPad Pro (12.9-inch) (3rd generation)", 264, False, False, True, False, False, True, True)
+            Device("iPad2",           "Device is an [iPad 2](https://support.apple.com/kb/SP622)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP622/SP622_01-ipad2-mul.png",                   ["iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4"], 9.7,  (3, 4),   "iPad 2", 132, False, False, False, False, False, False, 0),
+            Device("iPad3",           "Device is an [iPad (3rd generation)](https://support.apple.com/kb/SP647)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,1", "iPad3,2", "iPad3,3"],            9.7,  (3, 4),   "iPad 3", 264, False, False, False, False, False, False, 0),
+            Device("iPad4",           "Device is an [iPad (4th generation)](https://support.apple.com/kb/SP662)",       "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP662/sp662_ipad-4th-gen_color.jpg",             ["iPad3,4", "iPad3,5", "iPad3,6"],            9.7,  (3, 4),   "iPad 4", 264, False, False, False, False, False, False, 0),
+            Device("iPadAir",         "Device is an [iPad Air](https://support.apple.com/kb/SP692)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP692/SP692-specs_color-mul.png",                ["iPad4,1", "iPad4,2", "iPad4,3"],            9.7,  (3, 4),   "iPad Air", 264, False, False, False, False, False, False, 0),
+            Device("iPadAir2",        "Device is an [iPad Air 2](https://support.apple.com/kb/SP708)",                  "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP708/SP708-space_gray.jpeg",                    ["iPad5,3", "iPad5,4"],                       9.7,  (3, 4),   "iPad Air 2", 264, False, False, False, False, True, False, 0),
+            Device("iPad5",           "Device is an [iPad 5](https://support.apple.com/kb/SP751)",                      "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad6,11", "iPad6,12"],                     9.7,  (3, 4),   "iPad 5", 264, False, False, False, False, True, False, 0),
+            Device("iPad6",           "Device is an [iPad 6](https://support.apple.com/kb/NotYetAvailable)",            "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP751/ipad_5th_generation.png",                  ["iPad7,5", "iPad7,6"],                       9.7,  (3, 4),   "iPad 6", 264, False, False, False, False, True, False, 1),
+            Device("iPadAir3",        "Device is an [iPad Air (3rd generation)](INSERT LINK)",                          "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/mini/ipad-mini-compare-201903", ["iPad11,3", "iPad11,4"],       10.5, (3, 4),   "iPad Air (3rd generation)", 264, False, False, False, False, True, False, 1),
+            Device("iPadMini",        "Device is an [iPad Mini](https://support.apple.com/kb/SP661)",                   "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP661/sp661_ipad_mini_color.jpg",                ["iPad2,5", "iPad2,6", "iPad2,7"],            7.9,  (3, 4),   "iPad Mini", 163, False, True, False, False, False, False, 0),
+            Device("iPadMini2",       "Device is an [iPad Mini 2](https://support.apple.com/kb/SP693)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP693/SP693-specs_color-mul.png",                ["iPad4,4", "iPad4,5", "iPad4,6"],            7.9,  (3, 4),   "iPad Mini 2", 326, False, True, False, False, False, False, 0),
+            Device("iPadMini3",       "Device is an [iPad Mini 3](https://support.apple.com/kb/SP709)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP709/SP709-space_gray.jpeg",                    ["iPad4,7", "iPad4,8", "iPad4,9"],            7.9,  (3, 4),   "iPad Mini 3", 326, False, True, False, False, True, False, 0),
+            Device("iPadMini4",       "Device is an [iPad Mini 4](https://support.apple.com/kb/SP725)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP725/SP725ipad-mini-4.png",                     ["iPad5,1", "iPad5,2"],                       7.9,  (3, 4),   "iPad Mini 4", 326, False, True, False, False, True, False, 0),
+            Device("iPadMini5",       "Device is an [iPad Mini (5th generation)](INSERT LINK)",                         "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/air/ipad-air-compare-201903", ["iPad11,1", "iPad11,2"],    7.9,  (3, 4),   "iPad Mini (5th generation)", 326, False, True, False, False, True, False, 1),
+            Device("iPadPro9Inch",    "Device is an [iPad Pro 9.7-inch](https://support.apple.com/kb/SP739)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP739/SP739.png",                                ["iPad6,3", "iPad6,4"],                       9.7,  (3, 4),   "iPad Pro (9.7-inch)", 264, False, False, True, False, True, False, 1),
+            Device("iPadPro12Inch",   "Device is an [iPad Pro 12-inch](https://support.apple.com/kb/sp723)",                    "http://images.apple.com/v/ipad-pro/c/images/shared/buystrip/ipad_pro_large_2x.png",                        ["iPad6,7", "iPad6,8"],                       12.9, (3, 4),   "iPad Pro (12.9-inch)", 264, False, False, True, False, True, False, 1),
+            Device("iPadPro12Inch2",  "Device is an [iPad Pro 12-inch (2nd generation)](https://support.apple.com/kb/SP761)",                    "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-12in-hero-201706.png",            ["iPad7,1", "iPad7,2"],                       12.9, (3, 4),   "iPad Pro (12.9-inch) (2nd generation)", 264, False, False, True, False, True, False, 1),
+            Device("iPadPro10Inch",   "Device is an [iPad Pro 10.5-inch](https://support.apple.com/kb/SP762)",               "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP761/ipad-pro-10in-hero-201706.png",            ["iPad7,3", "iPad7,4"],                       10.5, (3, 4),   "iPad Pro (10.5-inch)", 264, False, False, True, False, True, False, 1),
+            Device("iPadPro11Inch",   "Device is an [iPad Pro 11-inch](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4"],                       11.0, (139, 199),   "iPad Pro (11-inch)", 264, False, False, True, False, False, True, 2),
+            Device("iPadPro12Inch3",   "Device is an [iPad Pro 12.9-inch (3rd generation)](https://support.apple.com/kb/not-published-yet)",     "https://support.apple.com/not-published-yet",            ["iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8"],                       12.9, (512, 683),   "iPad Pro (12.9-inch) (3rd generation)", 264, False, False, True, False, False, True, 2)
 
         ]
 
 homePods =  [
-            Device("homePod",         "Device is a [HomePod](https://www.apple.com/homepod/)",                          "https://images.apple.com/v/homepod/d/images/overview/homepod_side_dark_large_2x.jpg",                     ["AudioAccessory1,1"], -1,  (4, 5),   "HomePod", -1, False, False, False, False, False, False, False),
+            Device("homePod",         "Device is a [HomePod](https://www.apple.com/homepod/)",                          "https://images.apple.com/v/homepod/d/images/overview/homepod_side_dark_large_2x.jpg",                     ["AudioAccessory1,1"], -1,  (4, 5),   "HomePod", -1, False, False, False, False, False, False, 0),
             ]
 # tvOS
 tvs = [
-            Device("appleTV4",        "Device is an [Apple TV 4](https://support.apple.com/kb/SP724)",                  "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                                       ["AppleTV5,3"],                               0,    (),       "Apple TV 4", -1, False, False, False, False, False, False, False),
-            Device("appleTV4K",       "Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png",                            ["AppleTV6,2"],                               0,    (),       "Apple TV 4K", -1, False, False, False, False, False, False, False)
+            Device("appleTV4",        "Device is an [Apple TV 4](https://support.apple.com/kb/SP724)",                  "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                                       ["AppleTV5,3"],                               0,    (),       "Apple TV 4", -1, False, False, False, False, False, False, 0),
+            Device("appleTV4K",       "Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)",                 "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png",                            ["AppleTV6,2"],                               0,    (),       "Apple TV 4K", -1, False, False, False, False, False, False, 0)
       ]
 
 # watchOS
@@ -94,70 +94,70 @@ watches = [
             "appleWatchSeries0_38mm",
             "Device is an [Apple Watch (1st generation)](https://support.apple.com/kb/SP735)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM784/en_US/apple_watch_sport-240.png",
-            ["Watch1,1"], 1.5, (4,5), "Apple Watch (1st generation) 38mm", 290, False, False, False, False, False, False, False),
+            ["Watch1,1"], 1.5, (4,5), "Apple Watch (1st generation) 38mm", 290, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries0_42mm",
             "Device is an [Apple Watch (1st generation)](https://support.apple.com/kb/SP735)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM784/en_US/apple_watch_sport-240.png",
-            ["Watch1,2"], 1.6, (4,5), "Apple Watch (1st generation) 42mm", 303, False, False, False, False, False, False, False),
+            ["Watch1,2"], 1.6, (4,5), "Apple Watch (1st generation) 42mm", 303, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries1_38mm",
             "Device is an [Apple Watch Series 1](https://support.apple.com/kb/SP745)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM848/en_US/applewatch-series2-aluminum-temp-240.png",
-            ["Watch2,6"], 1.5, (4,5), "Apple Watch Series 1 38mm", 290, False, False, False, False, False, False, False),
+            ["Watch2,6"], 1.5, (4,5), "Apple Watch Series 1 38mm", 290, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries1_42mm",
             "Device is an [Apple Watch Series 1](https://support.apple.com/kb/SP745)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM848/en_US/applewatch-series2-aluminum-temp-240.png",
-            ["Watch2,7"], 1.6, (4,5), "Apple Watch Series 1 42mm", 303, False, False, False, False, False, False, False),
+            ["Watch2,7"], 1.6, (4,5), "Apple Watch Series 1 42mm", 303, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries2_38mm",
             "Device is an [Apple Watch Series 2](https://support.apple.com/kb/SP746)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM852/en_US/applewatch-series2-hermes-240.png",
-            ["Watch2,3"], 1.5, (4,5), "Apple Watch Series 2 38mm", 290, False, False, False, False, False, False, False),
+            ["Watch2,3"], 1.5, (4,5), "Apple Watch Series 2 38mm", 290, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries2_42mm",
             "Device is an [Apple Watch Series 2](https://support.apple.com/kb/SP746)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM852/en_US/applewatch-series2-hermes-240.png",
-            ["Watch2,4"], 1.6, (4,5), "Apple Watch Series 2 42mm", 303, False, False, False, False, False, False, False),
+            ["Watch2,4"], 1.6, (4,5), "Apple Watch Series 2 42mm", 303, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries3_38mm",
             "Device is an [Apple Watch Series 3](https://support.apple.com/kb/SP766)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM893/en_US/apple-watch-s3-nikeplus-240.png",
-            ["Watch3,1", "Watch3,3"], 1.5, (4,5), "Apple Watch Series 3 38mm", 290, False, False, False, False, False, False, False),
+            ["Watch3,1", "Watch3,3"], 1.5, (4,5), "Apple Watch Series 3 38mm", 290, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries3_42mm",
             "Device is an [Apple Watch Series 3](https://support.apple.com/kb/SP766)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM893/en_US/apple-watch-s3-nikeplus-240.png",
-            ["Watch3,2", "Watch3,4"], 1.6, (4,5), "Apple Watch Series 3 42mm", 303, False, False, False, False, False, False, False),
+            ["Watch3,2", "Watch3,4"], 1.6, (4,5), "Apple Watch Series 3 42mm", 303, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries4_40mm",
             "Device is an [Apple Watch Series 4](https://support.apple.com/kb/SP778)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM911/en_US/aw-series4-nike-240.png",
-            ["Watch4,1", "Watch4,3"], 1.8, (4,5), "Apple Watch Series 4 40mm", 326, False, False, False, False, False, False, False),
+            ["Watch4,1", "Watch4,3"], 1.8, (4,5), "Apple Watch Series 4 40mm", 326, False, False, False, False, False, False, 0),
 
 
             Device(
             "appleWatchSeries4_44mm",
             "Device is an [Apple Watch Series 4](https://support.apple.com/kb/SP778)",
             "https://km.support.apple.com/resources/sites/APPLE/content/live/IMAGES/0/IM911/en_US/aw-series4-nike-240.png",
-            ["Watch4,2", "Watch4,4"], 2.0, (4,5), "Apple Watch Series 4 44mm", 326, False, False, False, False, False, False, False),
+            ["Watch4,2", "Watch4,4"], 2.0, (4,5), "Apple Watch Series 4 44mm", 326, False, False, False, False, False, False, 0),
   ]
 
 iOSDevices = iPods + iPhones + iPads + homePods
@@ -472,11 +472,6 @@ public enum Device {
       return [${', '.join(list(map(lambda device: "." + device.caseName, list(filter(lambda device: device.hasFaceID == True, iOSDevices)))))}]
     }
 
-    /// All Apple Pencil Capable Devices
-    public static var allApplePencilCapableDevices: [Device] {
-      return [${', '.join(list(map(lambda device: "." + device.caseName, list(filter(lambda device: device.hasApplePencil == True, iOSDevices)))))}]
-    }
-
     /// Returns whether or not the device has Touch ID
     public var isTouchIDCapable: Bool {
       return isOneOf(Device.allTouchIDCapableDevices)
@@ -490,11 +485,6 @@ public enum Device {
     /// Returns whether or not the device has any biometric sensor (i.e. Touch ID or Face ID)
     public var hasBiometricSensor: Bool {
       return isTouchIDCapable || isFaceIDCapable
-    }
-
-    /// Returns whether or not the device is compatible with Apple Pencil
-    public var isApplePencilCapable: Bool {
-      return isOneOf(Device.allApplePencilCapableDevices)
     }
   #elseif os(tvOS)
     /// All TVs
@@ -908,6 +898,46 @@ extension Device {
       }
     } catch {
       return nil
+    }
+  }
+}
+#endif
+
+#if os(iOS)
+// MARK: - Apple Pencil
+extension Device {
+
+  /**
+    This option set describes the current Apple Pencils
+    - firstGeneration:  1st Generation Apple Pencil
+    - secondGeneration: 2nd Generation Apple Pencil
+   */
+  public struct ApplePencilSupport: OptionSet {
+
+    public var rawValue: UInt
+    public init(rawValue: UInt) {
+      self.rawValue = rawValue
+    }
+
+    public static let firstGeneration = ApplePencilSupport(rawValue: 0x01)
+    public static let secondGeneration = ApplePencilSupport(rawValue: 0x02)
+  }
+
+  /// All Apple Pencil Capable Devices
+  public static var allApplePencilCapableDevices: [Device] {
+    return [${', '.join(list(map(lambda device: "." + device.caseName, list(filter(lambda device: device.applePencilSupport != 0, iOSDevices)))))}]
+  }
+
+  /// Returns supported version of the Apple Pencil
+  public var applePencilSupport: ApplePencilSupport {
+    switch self {
+  % for device in list(filter(lambda device: device.applePencilSupport == 1, iOSDevices)):
+      case .${device.caseName}: return .firstGeneration
+  % end
+  % for device in list(filter(lambda device: device.applePencilSupport == 2, iOSDevices)):
+      case .${device.caseName}: return .secondGeneration
+  % end
+      default: return []
     }
   }
 }


### PR DESCRIPTION
Added a property to the Device enum to determine is the given device can use the Apple Pencil. Current list of supported devices taken off of the Apple Pencil support page: https://support.apple.com/en-us/HT205236