### PR TITLE
Fix isZoomed method

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -628,7 +628,7 @@ public enum Device {
       guard self != .iPhoneX && self != .iPhoneXS else { return false }
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
-        return UIScreen.main.nativeScale > 2.7
+        return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }


### PR DESCRIPTION
iOS 12.4 iPhone6 Plus Simulator reports `UIScreen.main.nativeScale = 3` for non-zoomed display.
Possbile resolution: add `< 3` checking.