### PR TITLE
Comply with renaming of Apple TV (4th generation) to Apple TV HD.

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -213,7 +213,7 @@ public enum Device {
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP773/homepod_space_gray_large_2x.jpg)
     case homePod
   #elseif os(tvOS)
-    /// Device is an [Apple TV 4](https://support.apple.com/kb/SP724)
+    /// Device is an [Apple TV HD](https://support.apple.com/kb/SP724) (Previously Apple TV (4th generation))
     ///
     /// ![Image](http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg)
     case appleTV4
@@ -983,7 +983,7 @@ extension Device: CustomStringConvertible {
       }
     #elseif os(tvOS)
       switch self {
-      case .appleTV4: return "Apple TV 4"
+      case .appleTV4: return "Apple TV HD"
       case .appleTV4K: return "Apple TV 4K"
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -88,8 +88,8 @@ homePods =  [
             ]
 # tvOS
 tvs = [
-            Device("appleTV4",       "Device is an [Apple TV 4](https://support.apple.com/kb/SP724)",                          "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                                     ["AppleTV5,3"],                               0,    (),         "Apple TV 4", -1, False, False, False, False, False, False, False, False, 0, False, 0),
-            Device("appleTV4K",      "Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)",                         "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png",                          ["AppleTV6,2"],                               0,    (),         "Apple TV 4K", -1, False, False, False, False, False, False, False, False, 0, False, 0)
+            Device("appleTV4",       "Device is an [Apple TV HD](https://support.apple.com/kb/SP724) (Previously Apple TV (4th generation))", "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                      ["AppleTV5,3"],                               0,    (),         "Apple TV HD", -1, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device("appleTV4K",      "Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)",                                        "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png",           ["AppleTV6,2"],                               0,    (),         "Apple TV 4K", -1, False, False, False, False, False, False, False, False, 0, False, 0)
       ]
 
 # watchOS

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -421,7 +421,7 @@ class DeviceKitTests: XCTestCase {
   }
 
   func testDescriptionFromIdentifier() {
-    XCTAssertEqual(Device.mapToDevice(identifier: "AppleTV5,3").description, "Apple TV 4")
+    XCTAssertEqual(Device.mapToDevice(identifier: "AppleTV5,3").description, "Apple TV HD")
     XCTAssertEqual(Device.mapToDevice(identifier: "AppleTV6,2").description, "Apple TV 4K")
   }
 


### PR DESCRIPTION
Apple TV (4th generation) has been renamed to be called Apple TV HD.

See
- https://support.apple.com/kb/SP724?locale=en_US
- https://support.apple.com/en-us/HT200008#appletv-4th