### PR TITLE
Fix the isZoomed() function.

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -624,11 +624,9 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
-      // TODO: Longterm we need a better solution for this!
-      guard self != .iPhoneX && self != .iPhoneXS else { return false }
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
-        return UIScreen.main.nativeScale > 2.7
+        return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -455,11 +455,9 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
-      // TODO: Longterm we need a better solution for this!
-      guard self != .iPhoneX && self != .iPhoneXS else { return false }
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
-        return UIScreen.main.nativeScale > 2.7
+        return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }


### PR DESCRIPTION
Credits to @vvit, see #195.

This removes the need to explicitly ignore iPhone X and iPhone Xs.