### PR TITLE
Disable the rebase error for if there are merge commits in the PR commit history

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -7,9 +7,10 @@ warn "PR is classed as Work in Progress" if github.pr_title.include? "[WIP]"
 warn "Big PR, consider splitting into smaller" if git.lines_of_code > 500
 
 # Ensure a clean commits history
-if git.commits.any? { |c| c.message =~ /^Merge branch '#{github.branch_for_base}'/ }
-  fail "Please rebase to get rid of the merge commits in this PR"
-end
+#if git.commits.any? { |c| c.message =~ /^Merge branch '#{github.branch_for_base}'/ }
+#  fail "Please rebase to get rid of the merge commits in this PR"
+#end
+# Disabled because currently we use squish and rebase instead of carrying over the commit history. This doesn't matter for the main repo.
 
 # Mainly to encourage writing up some reasoning about the PR, rather than
 # just leaving a title


### PR DESCRIPTION
We use squish and rebase anyway to merge PRs into master so this doesn't matter.