### PR TITLE
Rename the Apple TV HD enum to appleTVHD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,37 @@
 # Changelog
 
-## Version 2.3.0
+## Version 3.0.0
 
-Releasedate: 2019-10-02
+Releasedate: TBD
 
 ```ruby
 pod 'DeviceKit', :git => 'https://github.com/devicekit/DeviceKit.git', :branch => 'master'
 ```
 
-### New devices
-- Added support for the new september 2019 devices:
-  - iPad (7th generation)
+### Breaking changes
+- The enum for the Apple TV HD has been renamed from `.appleTV4` to `.appleTVHD`. (#211)
+
+### New features
+- You can now check which devices support wireless charging through the following variables: `Device.allDevicesWithWirelessChargingSupport` and `Device.current.supportsWirelessCharging` (#209)
+
+  ## Version 2.3.0
+
+  Releasedate: 2019-10-02
+
+  ```ruby
+  pod 'DeviceKit', '~> 2.3'
+  ```
+
+  ### New devices
+  - Added support for the new september 2019 devices:
+    - iPad (7th generation)
 
 ## Version 2.2.0
 
 Releasedate: 2019-09-24
 
 ```ruby
-pod 'DeviceKit', :git => 'https://github.com/devicekit/DeviceKit.git', :branch => 'master'
+pod 'DeviceKit', '~> 2.2'
 ```
 
 ### New devices

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -232,7 +232,7 @@ public enum Device {
     /// Device is an [Apple TV HD](https://support.apple.com/kb/SP724) (Previously Apple TV (4th generation))
     ///
     /// ![Image](http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg)
-    case appleTV4
+    case appleTVHD
     /// Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)
     ///
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png)
@@ -374,7 +374,7 @@ public enum Device {
       }
     #elseif os(tvOS)
       switch identifier {
-      case "AppleTV5,3": return appleTV4
+      case "AppleTV5,3": return appleTVHD
       case "AppleTV6,2": return appleTV4K
       case "i386", "x86_64": return simulator(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))
       default: return unknown(identifier)
@@ -741,7 +741,7 @@ public enum Device {
   #elseif os(tvOS)
     /// All TVs
     public static var allTVs: [Device] {
-       return [.appleTV4, .appleTV4K]
+       return [.appleTVHD, .appleTV4K]
     }
 
     /// All simulator TVs
@@ -1045,7 +1045,7 @@ extension Device: CustomStringConvertible {
       }
     #elseif os(tvOS)
       switch self {
-      case .appleTV4: return "Apple TV HD"
+      case .appleTVHD: return "Apple TV HD"
       case .appleTV4K: return "Apple TV 4K"
       case .simulator(let model): return "Simulator (\(model))"
       case .unknown(let identifier): return identifier

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -92,7 +92,7 @@ homePods = [
            ]
 # tvOS
 tvs = [
-            Device("appleTV4",       "Device is an [Apple TV HD](https://support.apple.com/kb/SP724) (Previously Apple TV (4th generation))", "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                      ["AppleTV5,3"],                               0,    (),         "Apple TV HD", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
+            Device("appleTVHD",      "Device is an [Apple TV HD](https://support.apple.com/kb/SP724) (Previously Apple TV (4th generation))", "http://images.apple.com/v/tv/c/images/overview/buy_tv_large_2x.jpg",                      ["AppleTV5,3"],                               0,    (),         "Apple TV HD", -1, False, False, False, False, False, False, False, False, False, 0, False, 0),
             Device("appleTV4K",      "Device is an [Apple TV 4K](https://support.apple.com/kb/SP769)",                                        "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP769/appletv4k.png",           ["AppleTV6,2"],                               0,    (),         "Apple TV 4K", -1, False, False, False, False, False, False, False, False, False, 0, False, 0)
       ]
 

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -429,10 +429,10 @@ class DeviceKitTests: XCTestCase {
   func testPPI() {
     // Non-applicable devices:
     // Apple TV
-    XCTAssertEqual(Device.appleTV4.ppi, nil)
+    XCTAssertEqual(Device.appleTVHD.ppi, nil)
     XCTAssertEqual(Device.appleTV4K.ppi, nil)
     // Simulators
-    XCTAssertEqual(Device.simulator(Device.appleTV4).ppi, nil)
+    XCTAssertEqual(Device.simulator(Device.appleTVHD).ppi, nil)
     XCTAssertEqual(Device.simulator(Device.appleTV4K).ppi, nil)
   }
 


### PR DESCRIPTION
The Apple TV (4th generation) was renamed to Apple TV HD a while ago, we already renamed the description variable to return "Apple TV HD" but not the enum since that would be a breaking change. This PR does actually rename the enum and thus this is a breaking change.

*Also updates the CHANGELOG.md.*