### PR TITLE
Add isSimulator for all targets

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -923,12 +923,6 @@ public enum Device {
               || (UIDevice.current.userInterfaceIdiom == .pad && isCurrent)
     }
 
-    /// Returns whether the device is any of the simulator
-    /// Useful when there is a need to check and skip running a portion of code (location request or others)
-    public var isSimulator: Bool {
-      return isOneOf(Device.allSimulators)
-    }
-
     /// If this device is a simulator return the underlying device,
     /// otherwise return `self`.
     public var realDevice: Device {
@@ -1075,6 +1069,12 @@ public enum Device {
   /// All simulators
   public static var allSimulators: [Device] {
     return allRealDevices.map(Device.simulator)
+  }
+  
+  /// Returns whether the device is any of the simulator
+  /// Useful when there is a need to check and skip running a portion of code (location request or others)
+  public var isSimulator: Bool {
+    return isOneOf(Device.allSimulators)
   }
 
   /**

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1070,7 +1070,7 @@ public enum Device {
   public static var allSimulators: [Device] {
     return allRealDevices.map(Device.simulator)
   }
-  
+
   /// Returns whether the device is any of the simulator
   /// Useful when there is a need to check and skip running a portion of code (location request or others)
   public var isSimulator: Bool {

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -694,7 +694,7 @@ public enum Device {
   public static var allSimulators: [Device] {
     return allRealDevices.map(Device.simulator)
   }
-  
+
   /// Returns whether the device is any of the simulator
   /// Useful when there is a need to check and skip running a portion of code (location request or others)
   public var isSimulator: Bool {

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -547,12 +547,6 @@ public enum Device {
               || (UIDevice.current.userInterfaceIdiom == .pad && isCurrent)
     }
 
-    /// Returns whether the device is any of the simulator
-    /// Useful when there is a need to check and skip running a portion of code (location request or others)
-    public var isSimulator: Bool {
-      return isOneOf(Device.allSimulators)
-    }
-
     /// If this device is a simulator return the underlying device,
     /// otherwise return `self`.
     public var realDevice: Device {
@@ -699,6 +693,12 @@ public enum Device {
   /// All simulators
   public static var allSimulators: [Device] {
     return allRealDevices.map(Device.simulator)
+  }
+  
+  /// Returns whether the device is any of the simulator
+  /// Useful when there is a need to check and skip running a portion of code (location request or others)
+  public var isSimulator: Bool {
+    return isOneOf(Device.allSimulators)
   }
 
   /**

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -19,7 +19,7 @@ class DeviceKitTests: XCTestCase {
   func testDeviceSimulator() {
     XCTAssertTrue(device.isOneOf(Device.allSimulators))
   }
-  
+
   func testIsSimulator() {
     XCTAssertTrue(device.isSimulator)
   }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -19,6 +19,10 @@ class DeviceKitTests: XCTestCase {
   func testDeviceSimulator() {
     XCTAssertTrue(device.isOneOf(Device.allSimulators))
   }
+  
+  func testIsSimulator() {
+    XCTAssertTrue(device.isSimulator)
+  }
 
   func testDeviceDescription() {
     XCTAssertTrue(device.description.hasPrefix("Simulator"))
@@ -30,9 +34,6 @@ class DeviceKitTests: XCTestCase {
 
   // MARK: - iOS
   #if os(iOS)
-  func testIsSimulator() {
-    XCTAssertTrue(device.isSimulator)
-  }
 
   func testIsPhoneIsPadIsPod() {
     // Test for https://github.com/devicekit/DeviceKit/issues/165 to prevent it from happening in the future.
@@ -510,9 +511,6 @@ class DeviceKitTests: XCTestCase {
 
   // MARK: - tvOS
   #if os(tvOS)
-  func testIsSimulator() {
-    XCTAssertTrue(Device.current.isOneOf(Device.allSimulatorTVs))
-  }
 
   func testDescriptionFromIdentifier() {
     XCTAssertEqual(Device.mapToDevice(identifier: "AppleTV5,3").description, "Apple TV HD")


### PR DESCRIPTION
`isSimulator` should be available on all targets, not just iOS.

Fixes https://github.com/devicekit/DeviceKit/issues/220