### PR TITLE
Add vendor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ xcuserdata
 Utilities/Docker/*.tar.gz
 .swiftpm
 Package.resolved
+vendor
 
 ## Generated Files
 # *.generated.swift # we have to check it in because of CocoaPods ...


### PR DESCRIPTION
`vendor` directory generated by Bundler should not be managed by git.