### PR TITLE
Remove unneeded check on iOS9 availability

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1263,11 +1263,7 @@ extension Device {
 
     /// The user enabled Low Power mode
     public var lowPowerMode: Bool {
-      if #available(iOS 9.0, *) {
-        return ProcessInfo.processInfo.isLowPowerModeEnabled
-      } else {
-        return false
-      }
+      return ProcessInfo.processInfo.isLowPowerModeEnabled
     }
 
     /// Provides a textual representation of the battery state.

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -883,11 +883,7 @@ extension Device {
 
     /// The user enabled Low Power mode
     public var lowPowerMode: Bool {
-      if #available(iOS 9.0, *) {
-        return ProcessInfo.processInfo.isLowPowerModeEnabled
-      } else {
-        return false
-      }
+      return ProcessInfo.processInfo.isLowPowerModeEnabled
     }
 
     /// Provides a textual representation of the battery state.


### PR DESCRIPTION
Now that DeviceKit dropped support of iOS8, this check is always true.