### PR TITLE
Fix description being used for Simulator safeDescription.

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1074,7 +1074,7 @@ extension Device: CustomStringConvertible {
       case .iPadPro11Inch2: return "iPad Pro (11-inch) (2nd generation)"
       case .iPadPro12Inch4: return "iPad Pro (12.9-inch) (4th generation)"
       case .homePod: return "HomePod"
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(watchOS)
@@ -1091,14 +1091,14 @@ extension Device: CustomStringConvertible {
       case .appleWatchSeries4_44mm: return "Apple Watch Series 4 44mm"
       case .appleWatchSeries5_40mm: return "Apple Watch Series 5 40mm"
       case .appleWatchSeries5_44mm: return "Apple Watch Series 5 44mm"
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(tvOS)
       switch self {
       case .appleTVHD: return "Apple TV HD"
       case .appleTV4K: return "Apple TV 4K"
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
     #endif
@@ -1159,7 +1159,7 @@ extension Device: CustomStringConvertible {
       case .iPadPro11Inch2: return "iPad Pro (11-inch) (2nd generation)"
       case .iPadPro12Inch4: return "iPad Pro (12.9-inch) (4th generation)"
       case .homePod: return "HomePod"
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(watchOS)
@@ -1176,14 +1176,14 @@ extension Device: CustomStringConvertible {
       case .appleWatchSeries4_44mm: return "Apple Watch Series 4 44mm"
       case .appleWatchSeries5_40mm: return "Apple Watch Series 5 40mm"
       case .appleWatchSeries5_44mm: return "Apple Watch Series 5 44mm"
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(tvOS)
       switch self {
       case .appleTVHD: return "Apple TV HD"
       case .appleTV4K: return "Apple TV 4K"
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
     #endif

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -755,7 +755,7 @@ extension Device: CustomStringConvertible {
 % for device in iOSDevices:
       case .${device.caseName}: return "${device.description}"
 % end
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(watchOS)
@@ -763,7 +763,7 @@ extension Device: CustomStringConvertible {
 % for device in watchOSDevices:
       case .${device.caseName}: return "${device.description}"
 % end
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(tvOS)
@@ -771,7 +771,7 @@ extension Device: CustomStringConvertible {
 % for device in tvOSDevices:
       case .${device.caseName}: return "${device.description}"
 % end
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
     #endif
@@ -787,7 +787,7 @@ extension Device: CustomStringConvertible {
   % for device in iOSDevices:
       case .${device.caseName}: return "${device.safeDescription}"
   % end
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(watchOS)
@@ -795,7 +795,7 @@ extension Device: CustomStringConvertible {
   % for device in watchOSDevices:
       case .${device.caseName}: return "${device.safeDescription}"
   % end
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
     #elseif os(tvOS)
@@ -803,7 +803,7 @@ extension Device: CustomStringConvertible {
   % for device in tvOSDevices:
       case .${device.caseName}: return "${device.safeDescription}"
   % end
-      case .simulator(let model): return "Simulator (\(model))"
+      case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
     #endif


### PR DESCRIPTION
safeDescription for iPhone XR simulator returns "Simulator (iPhone Xʀ)"

Fixes #255

Thanks @Oleygen for reporting!