### PR TITLE
Fix the `Device.systemName` property

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1029,12 +1029,14 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
-    #else
+    #elseif os(iOS)
     if isPad, #available(iOS 13, *), UIDevice.current.systemName == "iOS" {
-        return "iPadOS"
+      return "iPadOS"
     } else {
-        return UIDevice.current.systemName
+      return UIDevice.current.systemName
     }
+    #else
+    return UIDevice.current.systemName
     #endif
   }
 

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1030,7 +1030,11 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
     #else
-    return UIDevice.current.systemName
+    if isPad, #available(iOS 13, *), UIDevice.current.systemName == "iOS" {
+        return "iPadOS"
+    } else {
+        return UIDevice.current.systemName
+    }
     #endif
   }
 

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -706,7 +706,11 @@ public enum Device {
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
     #else
-    return UIDevice.current.systemName
+    if isPad, #available(iOS 13, *), UIDevice.current.systemName == "iOS" {
+        return "iPadOS"
+    } else {
+        return UIDevice.current.systemName
+    }
     #endif
   }
 

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -705,12 +705,14 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().systemName
-    #else
+    #elseif os(iOS)
     if isPad, #available(iOS 13, *), UIDevice.current.systemName == "iOS" {
-        return "iPadOS"
+      return "iPadOS"
     } else {
-        return UIDevice.current.systemName
+      return UIDevice.current.systemName
     }
+    #else
+    return UIDevice.current.systemName
     #endif
   }
 

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -69,6 +69,14 @@ class DeviceKitTests: XCTestCase {
     }
   }
 
+  func testSystemName() {
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      XCTAssertEqual(device.systemName, "iPadOS")
+    } else if UIDevice.current.userInterfaceIdiom == .phone {
+      XCTAssertEqual(device.systemName, "iOS")
+    }
+  }
+
   func testBattery() {
     XCTAssertTrue(Device.BatteryState.full > Device.BatteryState.charging(100))
     XCTAssertTrue(Device.BatteryState.charging(75) != Device.BatteryState.unplugged(75))


### PR DESCRIPTION
iPadOS system name for iPads was taken into account