### PR TITLE
Adjust Swiftlint rules.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,8 +13,6 @@ opt_in_rules:
   - closure_spacing
   - contains_over_first_not_nil
   - convenience_type
-  - discouraged_optional_boolean
-  - discouraged_optional_collection
   - empty_count
   - empty_string
   - empty_xctest_method
@@ -31,7 +29,6 @@ opt_in_rules:
   - vertical_parameter_alignment_on_call
   - pattern_matching_keywords
   - fatal_error_message
-  - implicit_return
   - implicitly_unwrapped_optional
   - joined_default_parameter
   - let_var_whitespace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -41,7 +41,6 @@ opt_in_rules:
   - multiple_closures_with_trailing_closure
   - nesting
   - notification_center_detachment
-  - number_separator
   - object_literal
   - operator_usage_whitespace
   - override_in_extension


### PR DESCRIPTION
Adjusted Swift lint rules to reduce spam of unnecessary warnings.