### PR TITLE
Fix Apple Watch Series 7 device identifier being incorrect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version 4.8.1
+
+Releasedate: 2022-10-28
+
+```ruby
+pod 'DeviceKit', '~> 4.8'
+```
+
+### Bugfixes
+
+- Fix Apple Watch Series 7 device identifier being incorrect. ([#329](https://github.com/devicekit/DeviceKit/pull/329))
+
 ## Version 4.8.0
 
 Releasedate: 2022-10-28

--- a/DeviceKit.podspec
+++ b/DeviceKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'DeviceKit'
-  s.version      = '4.8.0'
+  s.version      = '4.8.1'
   s.summary      = 'DeviceKit is a µ-framework that provides a value-type replacement of UIDevice.'
 
   s.description                = <<-DESC

--- a/DeviceKit.xcodeproj/project.pbxproj
+++ b/DeviceKit.xcodeproj/project.pbxproj
@@ -380,7 +380,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.8.0;
+				MARKETING_VERSION = 4.8.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -437,7 +437,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.8.0;
+				MARKETING_VERSION = 4.8.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 `DeviceKit` is a value-type replacement of [`UIDevice`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIDevice_Class/).
 
-## Current version 4.8.
+## Current version 4.8.1
 See our detailed [changelog](CHANGELOG.md) for the latest features, improvements and bug fixes.
 
 ## Features

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -576,7 +576,7 @@ public enum Device {
       case "Watch6,2", "Watch6,4": return appleWatchSeries6_44mm
       case "Watch5,9", "Watch5,11": return appleWatchSE_40mm
       case "Watch5,10", "Watch5,12": return appleWatchSE_44mm
-      case "Watch6,6", "Watch6,6": return appleWatchSeries7_41mm
+      case "Watch6,6", "Watch6,8": return appleWatchSeries7_41mm
       case "Watch6,7", "Watch6,9": return appleWatchSeries7_45mm
       case "Watch6,14", "Watch6,16": return appleWatchSeries8_41mm
       case "Watch6,15", "Watch6,17": return appleWatchSeries8_45mm

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -227,7 +227,7 @@ watches = [
             "appleWatchSeries7_41mm",
             "Device is an [Apple Watch Series 7](https://support.apple.com/kb/SP860)",
             "https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP860/series7-480_2x.png",
-            ["Watch6,6", "Watch6,6"], 1.8, (4,5), "Apple Watch Series 7 41mm", "Apple Watch Series 7 41mm", 326, False, False, False, False, False, False, False, True, False, 0, False, 0, False),
+            ["Watch6,6", "Watch6,8"], 1.8, (4,5), "Apple Watch Series 7 41mm", "Apple Watch Series 7 41mm", 326, False, False, False, False, False, False, False, True, False, 0, False, 0, False),
 
             Device(
             "appleWatchSeries7_45mm",


### PR DESCRIPTION
Watch6,6 was repeated.



https://everymac.com/ultimate-mac-lookup/?search_keywords=Watch6,8

