### PR TITLE
Make source code buildable on macOS

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(iOS) || os(watchOS) || os(tvOS)
+
 #if os(watchOS)
 import WatchKit
 #else
@@ -2228,3 +2230,5 @@ extension Device.CPU: CustomStringConvertible {
   #endif
   }
 }
+
+#endif

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -273,6 +273,8 @@ iOSDevices = iPods + iPhones + iPads + homePods
 tvOSDevices = tvs
 watchOSDevices = watches
 }%
+#if os(iOS) || os(watchOS) || os(tvOS)
+
 #if os(watchOS)
 import WatchKit
 #else
@@ -1427,3 +1429,5 @@ extension Device.CPU: CustomStringConvertible {
   #endif
   }
 }
+
+#endif

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(iOS) || os(watchOS) || os(tvOS)
+
 @testable import DeviceKit
 import XCTest
 
@@ -594,3 +596,5 @@ class DeviceKitTests: XCTestCase {
   #endif
 
 }
+
+#endif


### PR DESCRIPTION
This PR updates the package buildable on macOS, to address the SwiftUI preview issue on macOS, see https://github.com/devicekit/DeviceKit/issues/341