### PR TITLE
Update documentation of `Device.current.name` to not work as of iOS 16.0

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1181,6 +1181,8 @@ public enum Device {
   }
 
   /// The name identifying the device (e.g. "Dennis' iPhone").
+  /// As of iOS 16, this will return a generic String like "iPhone", unless your app has additional entitlements.
+  /// See the follwing link for more information: https://developer.apple.com/documentation/uikit/uidevice/1620015-name
   public var name: String? {
     guard isCurrent else { return nil }
     #if os(watchOS)

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -780,7 +780,9 @@ public enum Device {
     return self == Device.current
   }
 
-  /// The name identifying the device (e.g. "Dennis' iPhone"). As of iOS 16, this will return a generic String like "iPhone", unless your app has additional entitlements
+  /// The name identifying the device (e.g. "Dennis' iPhone").
+  /// As of iOS 16, this will return a generic String like "iPhone", unless your app has additional entitlements.
+  /// See the follwing link for more information: https://developer.apple.com/documentation/uikit/uidevice/1620015-name
   public var name: String? {
     guard isCurrent else { return nil }
     #if os(watchOS)

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -780,7 +780,7 @@ public enum Device {
     return self == Device.current
   }
 
-  /// The name identifying the device (e.g. "Dennis' iPhone").
+  /// The name identifying the device (e.g. "Dennis' iPhone"). As of iOS 16, this will return a generic String like "iPhone", unless your app has additional entitlements
   public var name: String? {
     guard isCurrent else { return nil }
     #if os(watchOS)


### PR DESCRIPTION
Via https://developer.apple.com/documentation/uikit/uidevice/1620015-name