### PR TITLE
Import UIKit and WatchKit conditionally to work around Xcode Previews not working on Mac

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(watchOS)
+#if canImport(WatchKit) || canImport(UIKit)
+
+#if canImport(WatchKit)
 import WatchKit
 #elseif canImport(UIKit)
 import UIKit
@@ -2228,3 +2230,5 @@ extension Device.CPU: CustomStringConvertible {
   #endif
   }
 }
+
+#endif

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -11,7 +11,7 @@
 
 #if os(watchOS)
 import WatchKit
-#else
+#elseif canImport(UIKit)
 import UIKit
 #endif
 

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -275,7 +275,7 @@ watchOSDevices = watches
 }%
 #if os(watchOS)
 import WatchKit
-#else
+#elseif canImport(UIKit)
 import UIKit
 #endif
 

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(WatchKit) || canImport(UIKit)
+
 %{
 class Device:
   def __init__(self, caseName, comment, imageURL, identifiers, diagonal, screenRatio, description, safeDescription, ppi, isPlusFormFactor, isPadMiniFormFactor, isPro, isXSeries, hasTouchID, hasFaceID, hasSensorHousing, supportsWirelessCharging, hasRoundedDisplayCorners, applePencilSupport, hasForce3dTouchSupport, cameras, hasLidarSensor, cpu):
@@ -273,7 +275,7 @@ iOSDevices = iPods + iPhones + iPads + homePods
 tvOSDevices = tvs
 watchOSDevices = watches
 }%
-#if os(watchOS)
+#if canImport(WatchKit)
 import WatchKit
 #elseif canImport(UIKit)
 import UIKit
@@ -1427,3 +1429,5 @@ extension Device.CPU: CustomStringConvertible {
   #endif
   }
 }
+
+#endif

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -12,6 +12,8 @@
 @testable import DeviceKit
 import XCTest
 
+#if canImport(UIKit) || canImport(WatchKit)
+
 class DeviceKitTests: XCTestCase {
 
   let device = Device.current
@@ -594,3 +596,5 @@ class DeviceKitTests: XCTestCase {
   #endif
 
 }
+
+#endif


### PR DESCRIPTION
This PR is practically identical to https://github.com/devicekit/DeviceKit/pull/342 and solves the same issue - when DeviceKit is used as framework dependency, Mac targets importing that framework fail to build for Xcode Previews.

This is not a build issue in Debug / Release configuration, it is only reproducible with Xcode Previews, as Xcode Previews seem to not be understanding platform filters (Link binary with libraries / Filters -> iOS, platformFilter = ios).

The only difference of this PR from #342 is that instead of if os(*) conditionals this PR uses #if canImport(*) statements, which should be more resilient, however it's obviously up to maintainers to select which approach is better suited for DeviceKit.