### PR TITLE
Adds compilation support for visionOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Version 5.0.1
+
+Releasedate: 2023-07-03
+
+```ruby
+pod 'DeviceKit', '~> 5.0'
+```
+
+### Fixes
+
+- Fixes compilation errors that occur when compiling DeviceKit for visionOS. ([#356](https://github.com/devicekit/DeviceKit/pull/356))
+
+### Important notes
+
+- Note that this version does not add full visionOS support to DeviceKit. It just allows DeviceKit to compile for visionOS.
+- When compiling this version of DeviceKit with Xcode 14 or lower, it will produce the following warning 3 times: `Unknown operating system for build configuration 'os'`
+
 ## Version 5.0.0
 
 Releasedate: 2022-11-01

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -931,12 +931,16 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
+      #if os(xrOS)
+      return nil
+      #else
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
         return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }
+      #endif
     }
 
     /// All Touch ID Capable Devices
@@ -1309,7 +1313,7 @@ public enum Device {
 
   /// The brightness level of the screen.
   public var screenBrightness: Int {
-    #if os(iOS)
+    #if os(iOS) && !os(xrOS)
     return Int(UIScreen.main.brightness * 100)
     #else
     return 100
@@ -1706,7 +1710,7 @@ extension Device.BatteryState: Comparable {
 }
 #endif
 
-#if os(iOS)
+#if os(iOS) && !os(xrOS)
 extension Device {
   // MARK: Orientation
     /**

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -556,12 +556,16 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
+      #if os(xrOS)
+      return nil
+      #else
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
         return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }
+      #endif
     }
 
     /// All Touch ID Capable Devices
@@ -846,7 +850,7 @@ public enum Device {
 
   /// The brightness level of the screen.
   public var screenBrightness: Int {
-    #if os(iOS)
+    #if os(iOS) && !os(xrOS)
     return Int(UIScreen.main.brightness * 100)
     #else
     return 100
@@ -1065,7 +1069,7 @@ extension Device.BatteryState: Comparable {
 }
 #endif
 
-#if os(iOS)
+#if os(iOS) && !os(xrOS)
 extension Device {
   // MARK: Orientation
     /**


### PR DESCRIPTION
Add support for compiling DeviceKit for visionOS. It does however produce the following warning 3 times when compiling DeviceKit with Xcode 14 or lower:

```swift
#if os(xrOS)
       ^
```

```
Unknown operating system for build configuration 'os'
```

Please note that full visionOS support is not the goal of this PR. It is just to fix the compilation errors that occur when compiling for visionOS.

Fixes https://github.com/devicekit/DeviceKit/issues/355