### PR TITLE
Add missing s9 CPU. 

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -2137,6 +2137,7 @@ extension Device {
     case s6
     case s7
     case s8
+    case s9
   #endif
     case unknown
   }
@@ -2309,6 +2310,7 @@ extension Device.CPU: CustomStringConvertible {
       case .s6: return "S6"
       case .s7: return "S7"
       case .s8: return "S8"
+      case .s9: return "S9"
       case .unknown: return "unknown"
     }
   #endif

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -1386,6 +1386,7 @@ watchOS_cpus = [
           CPU("s6", "S6"),
           CPU("s7", "S7"),
           CPU("s8", "S8"),
+          CPU("s9", "S9"),
 ]
 }%
 


### PR DESCRIPTION
    - ERROR | xcodebuild:  DeviceKit/Source/Device.generated.swift:2251:45: error: type 'Device.CPU' has no member 's9'
    - ERROR | xcodebuild:  DeviceKit/Source/Device.generated.swift:2252:45: error: type 'Device.CPU' has no member 's9'
    - ERROR | xcodebuild:  DeviceKit/Source/Device.generated.swift:2253:39: error: type 'Device.CPU' has no member 's9'