### PR TITLE
Add privacy manifest.

### DIFF
--- a/DeviceKit.podspec
+++ b/DeviceKit.podspec
@@ -22,5 +22,7 @@ Pod::Spec.new do |s|
   s.source                     = { :git => 'https://github.com/devicekit/DeviceKit.git', :tag => s.version }
   s.source_files               = 'Source/Device.generated.swift'
 
+  s.resources                  = 'PrivacyInfo.xcprivacy'
+
   s.requires_arc = true
 end

--- a/DeviceKit.xcodeproj/project.pbxproj
+++ b/DeviceKit.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		95C7E84D1C6130DB00B0189E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		95C7E84E1C61332300B0189E /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		FC5C20FA2A5197E2009406EE /* .github */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .github; sourceTree = "<group>"; };
+		FC6B86C22ACC1A0900E9D70B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		FCF1EAD323381E5700B609AA /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -118,6 +119,7 @@
 		95CBDB631BFD2B440065FC66 = {
 			isa = PBXGroup;
 			children = (
+				FC6B86C22ACC1A0900E9D70B /* PrivacyInfo.xcprivacy */,
 				FC5C20FA2A5197E2009406EE /* .github */,
 				95C7E83B1C6122BF00B0189E /* Source */,
 				95C7E8411C61241200B0189E /* Tests */,

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "DeviceKit",
-            targets: ["DeviceKit"])
+            targets: ["DeviceKit"]
+        )
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -31,11 +32,15 @@ let package = Package(
         .target(
             name: "DeviceKit",
             dependencies: [],
-            path: "Source"),
+            path: "Source",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
+        ),
         .testTarget(
             name: "DeviceKitTests",
             dependencies: ["DeviceKit"],
-            path: "Tests")
+            path: "Tests",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
+        )
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+				<string>E174.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
Add privacy manifest.

Cocoapods doesn't yet support privacy manifests properly. Not sure if SPM implementation is correct.

Fixes https://github.com/devicekit/DeviceKit/issues/366