### PR TITLE
Fix missing os warning in Swift Playgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 5.1.3
+Kudit updated.
+
 ## Version 5.1.0
 
 Releasedate: 2023-09-21

--- a/DeviceKit.xcodeproj/project.pbxproj
+++ b/DeviceKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -204,8 +204,9 @@
 		95CBDB641BFD2B440065FC66 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = "Dennis Weissmann";
 				TargetAttributes = {
 					6D7666191F1A083200F59630 = {
@@ -225,11 +226,11 @@
 			};
 			buildConfigurationList = 95CBDB671BFD2B440065FC66 /* Build configuration list for PBXProject "DeviceKit" */;
 			compatibilityVersion = "Xcode 9.3";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = 95CBDB631BFD2B440065FC66;
 			productRefGroup = 95CBDB701BFD2B5F0065FC66 /* Products */;
@@ -326,6 +327,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -334,6 +336,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -365,6 +368,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -376,24 +380,28 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 5.1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator driverkit iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 				WATCHOS_DEPLOYMENT_TARGET = 4.0;
@@ -427,28 +435,33 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 5.1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = me.dennisweissmann.DeviceKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator driverkit iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -485,7 +498,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -526,7 +539,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -566,8 +579,10 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -610,7 +625,9 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;

--- a/DeviceKit.xcodeproj/xcshareddata/xcschemes/DeviceKit.xcscheme
+++ b/DeviceKit.xcodeproj/xcshareddata/xcschemes/DeviceKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
     platforms: [
         .iOS(.v11),
         .tvOS(.v11),
+        .macOS(.v12),
         .watchOS(.v4)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     platforms: [
         .iOS(.v11),
         .tvOS(.v11),
-        .macOS(.v12),
+//        .macOS(.v12),
         .watchOS(.v4)
     ],
     products: [

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -980,15 +980,15 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
-      #if os(xrOS)
-      return nil
-      #else
+      #if canImport(UIScreen)
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
         return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }
+      #else
+      return nil
       #endif
     }
 
@@ -1371,7 +1371,7 @@ public enum Device {
 
   /// The brightness level of the screen.
   public var screenBrightness: Int {
-    #if os(iOS) && !os(xrOS)
+    #if canImport(UIScreen)
     return Int(UIScreen.main.brightness * 100)
     #else
     return 100
@@ -1782,7 +1782,9 @@ extension Device.BatteryState: Comparable {
 }
 #endif
 
-#if os(iOS) && !os(xrOS)
+// Unfortunately this is messy since os(visionOS) is not supported in swift < 5.9 (like Swift Playgrounds)
+#if swift(>=5.9)
+#if os(iOS) && !os(visionOS)
 extension Device {
   // MARK: Orientation
     /**
@@ -1803,6 +1805,30 @@ extension Device {
       }
     }
 }
+#endif
+#else
+#if os(iOS)
+extension Device {
+  // MARK: Orientation
+    /**
+      This enum describes the state of the orientation.
+      - Landscape: The device is in Landscape Orientation
+      - Portrait:  The device is in Portrait Orientation
+    */
+    public enum Orientation {
+      case landscape
+      case portrait
+    }
+
+    public var orientation: Orientation {
+      if UIDevice.current.orientation.isLandscape {
+        return .landscape
+      } else {
+        return .portrait
+      }
+    }
+}
+#endif
 #endif
 
 #if os(iOS)

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -2399,7 +2399,7 @@ extension Device.CPU: CustomStringConvertible {
       case .a17Pro: return "A17 Pro"
       case .m1: return "M1"
       case .m2: return "M2"
-      case .m3: return "M3"
+//      case .m3: return "M3"
       case .unknown: return "unknown"
     }
   #elseif os(watchOS)

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -11,7 +11,7 @@
 
 #if os(watchOS)
 import WatchKit
-#else
+#elseif canImport(UIKit)
 import UIKit
 #endif
 

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -299,7 +299,7 @@ watchOSDevices = watches
 }%
 #if os(watchOS)
 import WatchKit
-#else
+#elseif canImport(UIKit)
 import UIKit
 #endif
 

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -301,6 +301,9 @@ watchOSDevices = watches
 import WatchKit
 #elseif canImport(UIKit)
 import UIKit
+#else
+import Foundation
+import IOKit
 #endif
 
 // MARK: Device
@@ -384,6 +387,19 @@ public enum Device {
       return identifier + String(UnicodeScalar(UInt8(value)))
     }
     return identifier
+    
+    /* Possible code for macOS using IOKit:
+     
+     let service = IOServiceGetMatchingService(kIOMasterPortDefault,
+                                               IOServiceMatching("IOPlatformExpertDevice"))
+     var modelIdentifier: String?
+     if let modelData = IORegistryEntryCreateCFProperty(service, "model" as CFString, kCFAllocatorDefault, 0).takeRetainedValue() as? Data {
+         modelIdentifier = String(data: modelData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
+     }
+
+     IOObjectRelease(service)
+     return modelIdentifier
+*/
   }()
 
   /// Maps an identifier to a Device. If the identifier can not be mapped to an existing device, `UnknownDevice(identifier)` is returned.
@@ -416,6 +432,11 @@ public enum Device {
       case "i386", "x86_64", "arm64": return simulator(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "watchOS"))
       default: return unknown(identifier)
       }
+#elseif os(macOS)
+  switch identifier {
+  case "Mac14,6": return macBookProM2Max
+  default: return unknown(identifier)
+  }
     #endif
   }
 
@@ -475,7 +496,7 @@ public enum Device {
       case .simulator(let model): return model.screenRatio
       case .unknown: return (width: -1, height: -1)
       }
-    #elseif os(tvOS)
+    #else // if os(tvOS)
       return (width: -1, height: -1)
     #endif
   }
@@ -706,6 +727,10 @@ public enum Device {
     public var hasForceTouchSupport: Bool {
       return isOneOf(Device.allWatchesWithForceTouchSupport) || isOneOf(Device.allWatchesWithForceTouchSupport.map(Device.simulator))
     }
+  #elseif os(macOS)
+  public static var allMacs: [Device] {
+    return [.macBookProM2Max] // TODO: add others
+  }
   #endif
 
   /// Returns whether the current device is a SwiftUI preview canvas
@@ -726,6 +751,8 @@ public enum Device {
       return allTVs
     #elseif os(watchOS)
       return allWatches
+    #elseif os(macOS)
+      return allMacs
     #endif
   }
 
@@ -787,8 +814,17 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().name
-    #else
+    #elseif canImport(UIKit)
     return UIDevice.current.name
+    #elseif canImport(Foundation)
+    return ProcessInfo.processInfo.hostName
+    #else
+    // pulled from https://github.com/rjstelling/Hostess.swift/blob/master/Projects/Hostess/Hostess/Hostess.swift
+    var hostname = [CChar](repeating: 0x0, count: Int(NI_MAXHOST))
+    guard gethostname(&hostname, Int(NI_MAXHOST)) == noErr else {
+        return nil
+    }
+    return String(cString: hostname)
     #endif
   }
 
@@ -803,8 +839,12 @@ public enum Device {
     } else {
       return UIDevice.current.systemName
     }
-    #else
+    #elseif canImport(UIKit)
     return UIDevice.current.systemName
+    #elseif os(macOS)
+      return "macOS"
+    #else
+    return "unknownOS"
     #endif
   }
 
@@ -813,8 +853,10 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().systemVersion
-    #else
+  #elseif canImport(UIKit)
     return UIDevice.current.systemVersion
+    #else
+    return ProcessInfo.processInfo.operatingSystemVersionString
     #endif
   }
 
@@ -823,8 +865,10 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().model
-    #else
+#elseif canImport(UIKit)
     return UIDevice.current.model
+    #else
+    return Host.current().name
     #endif
   }
 
@@ -833,8 +877,10 @@ public enum Device {
     guard isCurrent else { return nil }
     #if os(watchOS)
     return WKInterfaceDevice.current().localizedModel
-    #else
+    #elseif canImport(UIKit)
     return UIDevice.current.localizedModel
+    #else
+    return Host.current().localizedName
     #endif
   }
 
@@ -856,7 +902,7 @@ public enum Device {
     case .simulator(let model): return model.ppi
     case .unknown: return nil
     }
-    #elseif os(tvOS)
+    #else //if os(tvOS)
     return nil
     #endif
   }
@@ -913,6 +959,12 @@ extension Device: CustomStringConvertible {
       case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
+    #else
+    switch self {
+    case .macBookProM2Max: return "MacBook Pro M2 Max 16\""
+    case .simulator(let model): return "Simulator (\(model.description))"
+    case .unknown(let identifier): return identifier
+    }
     #endif
   }
 
@@ -943,6 +995,12 @@ extension Device: CustomStringConvertible {
       case .${device.caseName}: return "${device.safeDescription}"
   % end
       case .simulator(let model): return "Simulator (\(model.safeDescription))"
+      case .unknown(let identifier): return identifier
+      }
+    #else
+      switch self {
+      case .macBookProM2Max: return "MacBook Pro M2 Max 16in"
+      case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
     #endif
@@ -1429,6 +1487,14 @@ extension Device {
 % for cpu in watchOS_cpus:
     case ${cpu.name}
 % end
+  #elseif os(macOS)
+    case i3
+    case i5
+    case i7
+    case i9
+    case m1
+    case m2
+    case m3
   #endif
     case unknown
   }
@@ -1459,6 +1525,12 @@ extension Device {
       case .simulator(let model): return model.cpu
       case .unknown: return .unknown
     }
+#else
+switch self {
+case .macBookProM2Max: return .m2
+case .simulator(let model): return model.cpu
+case .unknown: return .unknown
+}
   #endif
   }
 }
@@ -1479,6 +1551,17 @@ extension Device.CPU: CustomStringConvertible {
 % for cpu in watchOS_cpus:
       case .${cpu.name}: return "${cpu.description}"
 % end
+      case .unknown: return "unknown"
+    }
+  #else
+    switch self {
+      case .i3: return "Core i3"
+      case .i5: return "Core i5"
+      case .i7: return "Core i7"
+      case .i9: return "Core i9"
+      case .m1: return "M1"
+      case .m2: return "M2"
+      case .m3: return "M3"
       case .unknown: return "unknown"
     }
   #endif

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -580,15 +580,15 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
-      #if os(xrOS)
-      return nil
-      #else
+      #if canImport(UIScreen)
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
         return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }
+      #else
+      return nil
       #endif
     }
 
@@ -876,7 +876,7 @@ public enum Device {
 
   /// The brightness level of the screen.
   public var screenBrightness: Int {
-    #if os(iOS) && !os(xrOS)
+    #if canImport(UIScreen)
     return Int(UIScreen.main.brightness * 100)
     #else
     return 100
@@ -1095,7 +1095,9 @@ extension Device.BatteryState: Comparable {
 }
 #endif
 
-#if os(iOS) && !os(xrOS)
+// Unfortunately this is messy since os(visionOS) is not supported in swift < 5.9 (like Swift Playgrounds)
+#if swift(>=5.9)
+#if os(iOS) && !os(visionOS)
 extension Device {
   // MARK: Orientation
     /**
@@ -1116,6 +1118,30 @@ extension Device {
       }
     }
 }
+#endif
+#else
+#if os(iOS)
+extension Device {
+  // MARK: Orientation
+    /**
+      This enum describes the state of the orientation.
+      - Landscape: The device is in Landscape Orientation
+      - Portrait:  The device is in Portrait Orientation
+    */
+    public enum Orientation {
+      case landscape
+      case portrait
+    }
+
+    public var orientation: Orientation {
+      if UIDevice.current.orientation.isLandscape {
+        return .landscape
+      } else {
+        return .portrait
+      }
+    }
+}
+#endif
 #endif
 
 #if os(iOS)


### PR DESCRIPTION
In Swift Playgrounds (which doesn't yet support Swift 5.9), there is a warning that the OS is not supported since it doesn't know about xrOS (visionOS): "Unknown operating system for build configuration 'os'".  I've re-worked the conditional compiles to look for the module UIScreen which is more appropriate rather than the OS tests and added a Swift version compiler check for the case that isn't module dependent.  The last area is a bit redundant but I wasn't sure how to structure the statements without the redundancy since you can't do #if os(visionOS) without doing #if swift(>=5.9) first and separately.