### PR TITLE
Fix compilation on recent betas of visionOS

### DIFF
--- a/DeviceKit.xcodeproj/project.pbxproj
+++ b/DeviceKit.xcodeproj/project.pbxproj
@@ -389,10 +389,12 @@
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -446,8 +448,10 @@
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -983,16 +983,12 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
-      #if os(xrOS)
-      return nil
-      #else
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
         return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }
-      #endif
     }
 
     /// All Touch ID Capable Devices
@@ -1380,7 +1376,7 @@ public enum Device {
 
   /// The brightness level of the screen.
   public var screenBrightness: Int {
-    #if os(iOS) && !os(xrOS)
+    #if os(iOS)
     return Int(UIScreen.main.brightness * 100)
     #else
     return 100
@@ -1795,7 +1791,7 @@ extension Device.BatteryState: Comparable {
 }
 #endif
 
-#if os(iOS) && !os(xrOS)
+#if os(iOS)
 extension Device {
   // MARK: Orientation
     /**

--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -626,6 +626,9 @@ public enum Device {
       case "i386", "x86_64", "arm64": return simulator(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "watchOS"))
       default: return unknown(identifier)
       }
+    #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return unknown(identifier)
     #endif
   }
 
@@ -875,7 +878,7 @@ public enum Device {
       case .simulator(let model): return model.screenRatio
       case .unknown: return (width: -1, height: -1)
       }
-    #elseif os(tvOS)
+    #elseif os(tvOS) || os(visionOS)
       return (width: -1, height: -1)
     #endif
   }
@@ -1126,6 +1129,9 @@ public enum Device {
       return allTVs
     #elseif os(watchOS)
       return allWatches
+    #elseif os(visionOS)
+      // To be completed when more information becomes available.
+      return []
     #endif
   }
 
@@ -1353,6 +1359,9 @@ public enum Device {
     }
     #elseif os(tvOS)
     return nil
+    #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return nil
     #endif
   }
 
@@ -1504,6 +1513,8 @@ extension Device: CustomStringConvertible {
       case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
+    #elseif os(visionOS)
+      return "Apple Vision Pro"
     #endif
   }
 
@@ -1632,6 +1643,8 @@ extension Device: CustomStringConvertible {
       case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
+    #elseif os(visionOS)
+      return "Apple Vision Pro"
     #endif
   }
 
@@ -2266,6 +2279,9 @@ extension Device {
       case .simulator(let model): return model.cpu
       case .unknown: return .unknown
     }
+  #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return .unknown
   #endif
   }
 }
@@ -2315,6 +2331,9 @@ extension Device.CPU: CustomStringConvertible {
       case .s9: return "S9"
       case .unknown: return "unknown"
     }
+  #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return "unknown"
   #endif
   }
 }

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -583,16 +583,12 @@ public enum Device {
 
     public var isZoomed: Bool? {
       guard isCurrent else { return nil }
-      #if os(xrOS)
-      return nil
-      #else
       if Int(UIScreen.main.scale.rounded()) == 3 {
         // Plus-sized
         return UIScreen.main.nativeScale > 2.7 && UIScreen.main.nativeScale < 3
       } else {
         return UIScreen.main.nativeScale > UIScreen.main.scale
       }
-      #endif
     }
 
     /// All Touch ID Capable Devices
@@ -885,7 +881,7 @@ public enum Device {
 
   /// The brightness level of the screen.
   public var screenBrightness: Int {
-    #if os(iOS) && !os(xrOS)
+    #if os(iOS)
     return Int(UIScreen.main.brightness * 100)
     #else
     return 100
@@ -1108,7 +1104,7 @@ extension Device.BatteryState: Comparable {
 }
 #endif
 
-#if os(iOS) && !os(xrOS)
+#if os(iOS)
 extension Device {
   // MARK: Orientation
     /**

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -416,6 +416,9 @@ public enum Device {
       case "i386", "x86_64", "arm64": return simulator(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "watchOS"))
       default: return unknown(identifier)
       }
+    #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return unknown(identifier)
     #endif
   }
 
@@ -475,7 +478,7 @@ public enum Device {
       case .simulator(let model): return model.screenRatio
       case .unknown: return (width: -1, height: -1)
       }
-    #elseif os(tvOS)
+    #elseif os(tvOS) || os(visionOS)
       return (width: -1, height: -1)
     #endif
   }
@@ -726,6 +729,9 @@ public enum Device {
       return allTVs
     #elseif os(watchOS)
       return allWatches
+    #elseif os(visionOS)
+      // To be completed when more information becomes available.
+      return []
     #endif
   }
 
@@ -858,6 +864,9 @@ public enum Device {
     }
     #elseif os(tvOS)
     return nil
+    #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return nil
     #endif
   }
 
@@ -913,6 +922,8 @@ extension Device: CustomStringConvertible {
       case .simulator(let model): return "Simulator (\(model.description))"
       case .unknown(let identifier): return identifier
       }
+    #elseif os(visionOS)
+      return "Apple Vision Pro"
     #endif
   }
 
@@ -945,6 +956,8 @@ extension Device: CustomStringConvertible {
       case .simulator(let model): return "Simulator (\(model.safeDescription))"
       case .unknown(let identifier): return identifier
       }
+    #elseif os(visionOS)
+      return "Apple Vision Pro"
     #endif
   }
 
@@ -1433,6 +1446,9 @@ extension Device {
       case .simulator(let model): return model.cpu
       case .unknown: return .unknown
     }
+  #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return .unknown
   #endif
   }
 }
@@ -1455,6 +1471,9 @@ extension Device.CPU: CustomStringConvertible {
 % end
       case .unknown: return "unknown"
     }
+  #elseif os(visionOS)
+    // To be completed when more information becomes available.
+    return "unknown"
   #endif
   }
 }


### PR DESCRIPTION
In recent visionOS betas, #if os(xrOS) is now #if os(visionOS), and #if os(iOS) no longer returns true on visionOS. This required some updates to DeviceKit.

This is not meant to be a PR to fully support Apple Vision Pro information, just something to get DeviceKit building properly on the latest visionOS betas, and provide some scaffolding to start filling out information as it becomes available.

Fixes https://github.com/devicekit/DeviceKit/issues/370