### PR TITLE
fix: Use cocoapod resource_bundles for PrivacyInfo

### DIFF
--- a/DeviceKit.podspec
+++ b/DeviceKit.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.source                     = { :git => 'https://github.com/devicekit/DeviceKit.git', :tag => s.version }
   s.source_files               = 'Source/Device.generated.swift'
 
-  s.resources                  = 'Source/PrivacyInfo.xcprivacy'
+  s.resource_bundles = { 'DeviceKit' => 'Source/PrivacyInfo.xcprivacy' }
 
   s.requires_arc = true
 end


### PR DESCRIPTION
Changed the inclusion of PrivacyInfo.xcprivacy to resource_bundles for cocoapod to avoid resource name collision when the user uses cocoapod as static library.
 #396 