### PR TITLE
Fix ruby version for Danger not found.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.6.3
+          ruby-version: 2.6.10
 
       - uses: MeilCli/danger-action@v5
         with:


### PR DESCRIPTION
Fixes Danger not working anymore:

```
Downloading Ruby
  https://github.com/ruby/ruby-builder/releases/download/toolcache/ruby-2.6.3-macos-13-arm64.tar.gz
  Took   0.34 seconds
Error: Error: Unexpected HTTP response: 404
```