### PR TITLE
Add support for devices with a notch and corresponding tests

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -1167,6 +1167,17 @@ public enum Device {
       return isOneOf(Device.allDevicesWithDynamicIsland) || isOneOf(Device.allDevicesWithDynamicIsland.map(Device.simulator))
     }
 
+    /// All devices that have a notch.
+    public static var allDevicesWithNotch: [Device] {
+        return [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax, .iPhone12, .iPhone12Mini, .iPhone12Pro, .iPhone12ProMax, .iPhone13, .iPhone13Mini, .iPhone13Pro, .iPhone13ProMax, .iPhone14, .iPhone14Plus
+        ]
+    }
+
+    /// Returns whether or not the device has a notch.
+    public var hasNotch: Bool {
+        return isOneOf(allDevicesWithNotch) || isOneOf(allDevicesWithNotch.map(Device.simulator))
+    }
+
     /// All devices that have 3D Touch support.
     public static var allDevicesWith3dTouchSupport: [Device] {
       return [.iPhone6s, .iPhone6sPlus, .iPhone7, .iPhone7Plus, .iPhone8, .iPhone8Plus, .iPhoneX, .iPhoneXS, .iPhoneXSMax]

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -527,6 +527,31 @@ class DeviceKitTests: XCTestCase {
     }
   }
 
+  func testHasNotch() {
+    let notchDevices: [Device] = [
+      .iPhoneX,
+      .iPhoneXS,
+      .iPhoneXSMax,
+      .iPhoneXR,
+      .iPhone11,
+      .iPhone11Pro,
+      .iPhone11ProMax,
+      .iPhone12,
+      .iPhone12Mini,
+      .iPhone12Pro,
+      .iPhone12ProMax,
+      .iPhone13,
+      .iPhone13Mini,
+      .iPhone13Pro,
+      .iPhone13ProMax,
+      .iPhone14,
+      .iPhone14Plus
+    ]
+    for device in Device.allRealDevices {
+      XCTAssertTrue(device.hasNotch == device.isOneOf(notchDevices), "testHasNotch failed for \(device.description)")
+    }
+  }
+
   func testHas5gSupport() {
     let has5gDevices: [Device] = [
       .iPhone12,


### PR DESCRIPTION
- Introduce `allDevicesWithNotch` static property to list devices with a notch.
- Implement `hasNotch` instance property to check if a device has a notch.
- Add `testHasNotch` method in `DeviceKitTests` to verify the `hasNotch` functionality.