### PR TITLE
Add missing Apple Watch Series 9 identifiers and spec link

### DIFF
--- a/Source/Device.generated.swift
+++ b/Source/Device.generated.swift
@@ -512,11 +512,11 @@ public enum Device {
     ///
     /// ![Image](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/SP879/apple-watch-ultra_2x.png)
     case appleWatchUltra
-    /// Device is an [Apple Watch Series 9]()
+    /// Device is an [Apple Watch Series 9](https://support.apple.com/kb/SP905)
     ///
     /// ![Image]()
     case appleWatchSeries9_41mm
-    /// Device is an [Apple Watch Series 9]()
+    /// Device is an [Apple Watch Series 9](https://support.apple.com/kb/SP905)
     ///
     /// ![Image]()
     case appleWatchSeries9_45mm
@@ -695,8 +695,8 @@ public enum Device {
       case "Watch6,10", "Watch6,12": return appleWatchSE2_40mm
       case "Watch6,11", "Watch6,13": return appleWatchSE2_44mm
       case "Watch6,18": return appleWatchUltra
-      case "Watch7,3": return appleWatchSeries9_41mm
-      case "Watch7,4": return appleWatchSeries9_45mm
+      case "Watch7,1", "Watch7,3": return appleWatchSeries9_41mm
+      case "Watch7,2", "Watch7,4": return appleWatchSeries9_45mm
       case "Watch7,5": return appleWatchUltra2
       case "Watch7,8", "Watch7,10": return appleWatchSeries10_42mm
       case "Watch7,9", "Watch7,11": return appleWatchSeries10_46mm

--- a/Source/Device.swift.gyb
+++ b/Source/Device.swift.gyb
@@ -289,15 +289,15 @@ watches = [
 
             Device(
             "appleWatchSeries9_41mm",
-            "Device is an [Apple Watch Series 9]()",
+            "Device is an [Apple Watch Series 9](https://support.apple.com/kb/SP905)",
             "",
-            ["Watch7,3"], 1.9, (4,5), "Apple Watch Series 9 41mm", "Apple Watch Series 9 41mm", 326, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s9", False, False),
+            ["Watch7,1", "Watch7,3"], 1.9, (4,5), "Apple Watch Series 9 41mm", "Apple Watch Series 9 41mm", 326, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s9", False, False),
 
             Device(
             "appleWatchSeries9_45mm",
-            "Device is an [Apple Watch Series 9]()",
+            "Device is an [Apple Watch Series 9](https://support.apple.com/kb/SP905)",
             "",
-            ["Watch7,4"], 2.0, (4,5), "Apple Watch Series 9 45mm", "Apple Watch Series 9 45mm", 326, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s9", False, False),
+            ["Watch7,2", "Watch7,4"], 2.0, (4,5), "Apple Watch Series 9 45mm", "Apple Watch Series 9 45mm", 326, False, False, False, False, False, False, False, True, False, False, 0, False, 0, False, "s9", False, False),
 
              Device(
             "appleWatchUltra2",
@@ -1501,7 +1501,7 @@ iOS_cpus = [
           CPU("m3", "M3"),
           CPU("m4", "M4"),
       ]
-      
+
 watchOS_cpus = [
           CPU("s1", "S1"),
           CPU("s1P", "S1P"),


### PR DESCRIPTION
Hi,
While reviewing Apple Watch model logging, I noticed that "Watch7,1" and "Watch7,2" weren’t mapped to `Apple Watch Series 9`. So I updated the `gyb` file accordingly and also added the spec link.

Refs:
- https://appledb.dev/device/identifier/Watch7,1.html
- https://appledb.dev/device/identifier/Watch7,2.html

Just let me know if anything should be changed. Cheers.